### PR TITLE
fix(general): custom output path

### DIFF
--- a/skills/preview-csv/lib/browser-utils.sh
+++ b/skills/preview-csv/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-csv/run.sh
+++ b/skills/preview-csv/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-d3/lib/browser-utils.sh
+++ b/skills/preview-d3/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-d3/run.sh
+++ b/skills/preview-d3/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-diff/lib/browser-utils.sh
+++ b/skills/preview-diff/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-diff/run.sh
+++ b/skills/preview-diff/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-json/lib/browser-utils.sh
+++ b/skills/preview-json/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-json/run.sh
+++ b/skills/preview-json/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-leaflet/lib/browser-utils.sh
+++ b/skills/preview-leaflet/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-leaflet/run.sh
+++ b/skills/preview-leaflet/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-markdown/lib/browser-utils.sh
+++ b/skills/preview-markdown/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-markdown/run.sh
+++ b/skills/preview-markdown/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-mermaid/lib/browser-utils.sh
+++ b/skills/preview-mermaid/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-mermaid/run.sh
+++ b/skills/preview-mermaid/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/skills/preview-threejs/lib/browser-utils.sh
+++ b/skills/preview-threejs/lib/browser-utils.sh
@@ -179,6 +179,59 @@ get_temp_file_path() {
 }
 
 #######################################
+# Get output file path (custom or temp)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_temp_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-100)
+    [ -z "$safe_filename" ] && safe_filename="file"
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
 # Clean up old preview files
 # Arguments:
 #   $1 - Skill name (optional, cleans all if not specified)

--- a/skills/preview-threejs/run.sh
+++ b/skills/preview-threejs/run.sh
@@ -9,10 +9,32 @@
 
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (standalone skill)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,7 +138,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")

--- a/src/preview-skills/run.sh
+++ b/src/preview-skills/run.sh
@@ -1,10 +1,32 @@
 #!/usr/bin/env bash
 
 # Universal Preview Tool
-# Usage: ./run.sh <file> [background]
-#    OR: cat content | ./run.sh [name] [background]
+# Usage: ./run.sh <file> [-o output]
+#    OR: cat content | ./run.sh [name] [-o output]
+#
+# Options:
+#   -o, --output  Output file path or directory (default: /tmp/preview-skills/)
 
 set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # Get directories (tools are inside skills/)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -108,7 +130,7 @@ if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
 fi
 
 # Generate output file path
-OUTPUT_FILE=$(get_temp_file_path "$TOOL_NAME" "$FILENAME")
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
 
 # Load common JavaScript libraries
 UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")


### PR DESCRIPTION
### Usage examples:

```
# Custom file path
./skills/preview-markdown/run.sh file.md -o /path/to/output.html

# Custom directory (uses filename as output name)
./skills/preview-markdown/run.sh file.md -o /path/to/dir

# Piped content with custom output
cat content.md | ./skills/preview-markdown/run.sh doc -o ./output.html

# Default behavior (unchanged)
./skills/preview-markdown/run.sh file.md
```