### PR TITLE
feat(pdf): add PDF export button and print styles

### DIFF
--- a/skills/preview-markdown/templates/scripts/markdown-renderer.js
+++ b/skills/preview-markdown/templates/scripts/markdown-renderer.js
@@ -96,6 +96,7 @@ const stats = `${lines} lines • ${words} words • ${chars} chars`;
 const toolbarItems = [
   createButton('Copy Markdown', 'copyMarkdown()', '📋'),
   createButton('Copy HTML', 'copyHTML()', '📄'),
+  createButton('Export PDF', 'window.print()', '🖨'),
 ];
 
 container.innerHTML =

--- a/skills/preview-markdown/templates/styles/markdown.css
+++ b/skills/preview-markdown/templates/styles/markdown.css
@@ -272,3 +272,50 @@
     margin-left: 16px;
     padding-left: 2em;
 }
+
+/* Print styles for PDF export */
+@media print {
+    html, body {
+        height: auto;
+        overflow: visible;
+        -webkit-print-color-adjust: exact !important;
+        print-color-adjust: exact !important;
+    }
+
+    .preview-header,
+    .preview-footer {
+        display: none !important;
+    }
+
+    #content {
+        height: auto;
+    }
+
+    .preview-body {
+        overflow: visible;
+        padding-left: var(--spacing-2xl);
+        padding-right: var(--spacing-2xl);
+        background: transparent;
+    }
+
+    #markdown-content {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 40px;
+        background: var(--color-surface-primary);
+    }
+
+    #markdown-content table {
+        display: table;
+        overflow: visible;
+    }
+
+    #markdown-content pre {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }
+
+    #markdown-content .header-anchor {
+        display: none;
+    }
+}


### PR DESCRIPTION
This pull request adds PDF export functionality to the Markdown previewer and introduces print-specific styles to ensure exported PDFs have a clean and readable layout.

**PDF Export Feature:**
- Added an "Export PDF" button to the toolbar in `markdown-renderer.js`, which triggers the browser's print dialog for PDF export.

**Print Styles for PDF Export:**
- Implemented a set of print-specific CSS rules in `markdown.css` to:
  - Hide non-essential UI elements (header and footer) during printing.
  - Adjust layout, spacing, and background for optimal PDF appearance.
  - Improve table and code block formatting for print.
  - Remove header anchors to avoid clutter in the exported document.