### PR TITLE
feat(svg): add preview-svg skill for animated SVG explainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 **Reduce cognitive load when reviewing AI agent work.** Transform plans, diffs, and data into navigable previews.
 
-| Name                                                                                                  | Description                                                   | File Types          |
-| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------- |
-| [**preview-plan**](https://veelenga.github.io/preview-skills/examples/plan/sample.html)               | Navigable plans with sidebar TOC and progress tracking        | `.plan.md`, `.plan` |
-| [**preview-csv**](https://veelenga.github.io/preview-skills/examples/csv/employees.html)              | Sortable tables with search, filtering, and column statistics | `.csv`              |
-| [**preview-json**](https://veelenga.github.io/preview-skills/examples/json/sample.html)               | Syntax highlighting with collapsible tree structure           | `.json`, `.jsonl`   |
-| [**preview-markdown**](https://veelenga.github.io/preview-skills/examples/markdown/sample.html)       | GitHub-flavored rendering with syntax highlighting            | `.md`, `.markdown`  |
-| [**preview-mermaid**](https://veelenga.github.io/preview-skills/examples/mermaid/sample.html)         | Interactive diagrams (flowcharts, sequences, ER, etc.)        | `.mmd`, `.mermaid`  |
-| [**preview-diff**](https://veelenga.github.io/preview-skills/examples/diff/feature.html)              | GitHub-style diffs with side-by-side comparison               | `.diff`, `.patch`   |
-| [**preview-d3**](https://veelenga.github.io/preview-skills/examples/d3/sample.html)                   | Interactive 2D data visualizations with zoom and pan          | `.d3`               |
-| [**preview-threejs**](https://veelenga.github.io/preview-skills/examples/threejs/sample.html)         | Interactive 3D visualizations with orbit controls             | `.threejs`, `.3d`   |
-| [**preview-leaflet**](https://veelenga.github.io/preview-skills/examples/leaflet/longest-trails.html) | Interactive maps with markers and routes                      | `.leaflet`, `.map`  |
+| Name                                                                                                  | Description                                                     | File Types          |
+| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------- |
+| [**preview-plan**](https://veelenga.github.io/preview-skills/examples/plan/sample.html)               | Navigable plans with sidebar TOC and progress tracking          | `.plan.md`, `.plan` |
+| [**preview-csv**](https://veelenga.github.io/preview-skills/examples/csv/employees.html)              | Sortable tables with search, filtering, and column statistics   | `.csv`              |
+| [**preview-json**](https://veelenga.github.io/preview-skills/examples/json/sample.html)               | Syntax highlighting with collapsible tree structure             | `.json`, `.jsonl`   |
+| [**preview-markdown**](https://veelenga.github.io/preview-skills/examples/markdown/sample.html)       | GitHub-flavored rendering with syntax highlighting              | `.md`, `.markdown`  |
+| [**preview-mermaid**](https://veelenga.github.io/preview-skills/examples/mermaid/sample.html)         | Interactive diagrams (flowcharts, sequences, ER, etc.)          | `.mmd`, `.mermaid`  |
+| [**preview-diff**](https://veelenga.github.io/preview-skills/examples/diff/feature.html)              | GitHub-style diffs with side-by-side comparison                 | `.diff`, `.patch`   |
+| [**preview-d3**](https://veelenga.github.io/preview-skills/examples/d3/sample.html)                   | Interactive 2D data visualizations with zoom and pan            | `.d3`               |
+| [**preview-threejs**](https://veelenga.github.io/preview-skills/examples/threejs/sample.html)         | Interactive 3D visualizations with orbit controls               | `.threejs`, `.3d`   |
+| [**preview-leaflet**](https://veelenga.github.io/preview-skills/examples/leaflet/longest-trails.html) | Interactive maps with markers and routes                        | `.leaflet`, `.map`  |
+| [**preview-svg**](https://veelenga.github.io/preview-skills/examples/svg/bubble-sort.html)            | Animated SVGs with play/pause, scrub, zoom — concept explainers | `.svg`              |
 
 ![Demo](docs/demo.gif)
 
@@ -100,6 +101,10 @@ Or use natural language:
 # 3D and maps
 /preview-threejs examples/threejs/sample.threejs
 /preview-leaflet examples/leaflet/longest-trails.leaflet
+
+# Animated SVG (concept explainers)
+/preview-svg examples/svg/bubble-sort.svg
+/preview-svg examples/svg/load-balancer.svg
 ```
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Or use natural language:
 # Animated SVG (concept explainers)
 /preview-svg examples/svg/bubble-sort.svg
 /preview-svg examples/svg/load-balancer.svg
+/preview-svg examples/svg/https-handshake.svg
 ```
 
 ### Running tests

--- a/docs/index.html
+++ b/docs/index.html
@@ -857,6 +857,48 @@
         </div>
 
         <div class="skill-card glass">
+          <h3>preview-svg</h3>
+          <p>Animated SVG previews with play/pause, timeline scrubbing, and zoom for explaining concepts visually.</p>
+          <div class="file-types">
+            <span class="file-type">.svg</span>
+          </div>
+          <div class="example-links">
+            <a href="examples/svg/heartbeat.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              ECG Heartbeat
+            </a>
+            <a href="examples/svg/motion-path.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              Motion path
+            </a>
+            <a href="examples/svg/bubble-sort.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              Bubble sort
+            </a>
+            <a href="examples/svg/load-balancer.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              Load balancer
+            </a>
+          </div>
+        </div>
+
+        <div class="skill-card glass">
           <h3>preview-leaflet</h3>
           <p>Interactive maps with markers, routes, and geographic data.</p>
           <div class="file-types">

--- a/docs/index.html
+++ b/docs/index.html
@@ -895,6 +895,14 @@
               </svg>
               Load balancer
             </a>
+            <a href="examples/svg/https-handshake.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              HTTPS handshake
+            </a>
           </div>
         </div>
 

--- a/examples/svg/bubble-sort.svg
+++ b/examples/svg/bubble-sort.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240" font-family="-apple-system, system-ui, sans-serif">
+  <!--
+    Bubble sort visualization for [3, 1, 4, 2] → [1, 2, 3, 4]
+    8s loop, 5 SMIL-driven comparison steps:
+      Pass 1: swap(3,1), no-swap(3,4), swap(4,2)
+      Pass 2: no-swap(1,3), swap(3,2)
+    Each bar's x position is animated through the full sort sequence.
+    The comparison cursor jumps between adjacent slots at each step.
+    keyTimes:  0    0.2   0.4   0.6   0.8   1.0
+  -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="320" height="240" fill="url(#bg)"/>
+
+  <!-- Title -->
+  <text x="160" y="28" text-anchor="middle" font-size="14" font-weight="600" fill="#1e293b">
+    Bubble Sort: [3, 1, 4, 2]
+  </text>
+
+  <!-- Baseline -->
+  <line x1="20" y1="200" x2="300" y2="200" stroke="#94a3b8" stroke-width="1"/>
+
+  <!-- Slot markers -->
+  <g font-size="10" fill="#64748b" text-anchor="middle">
+    <text x="65"  y="218">0</text>
+    <text x="125" y="218">1</text>
+    <text x="185" y="218">2</text>
+    <text x="245" y="218">3</text>
+  </g>
+
+  <!-- Comparison cursor (orange arrow under the active pair) -->
+  <g>
+    <polygon points="-10,0 10,0 0,-10" fill="#f97316"/>
+    <animateTransform attributeName="transform" type="translate"
+      calcMode="discrete"
+      keyTimes="0;     0.2;   0.4;   0.6;   0.8;   1"
+      values  ="95,228; 95,228; 155,228; 215,228; 95,228; 155,228"
+      dur="8s" repeatCount="indefinite"/>
+  </g>
+
+  <!--
+    Bars. Each bar's value is encoded in height/color/label. x is animated.
+    Slot x positions (bar left edge): 40, 100, 160, 220 (width 50, gap 10).
+    Center x for label: slot + 25 → 65, 125, 185, 245.
+    Height map: value 1→30, 2→60, 3→90, 4→120 (top y = 200 - h).
+  -->
+
+  <!-- value=3: x trajectory 40, 100, 100, 100, 160, 160 -->
+  <g>
+    <rect width="50" height="90" y="110" fill="#fb923c" stroke="#9a3412" stroke-width="1.5" rx="3">
+      <animate attributeName="x"
+        keyTimes="0;   0.2; 0.4; 0.6; 0.8; 1"
+        values  ="40; 100; 100; 100; 160; 160"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0 0 1 1; 0.4 0 0.2 1; 0.4 0 0.2 1; 0 0 1 1"/>
+    </rect>
+    <text y="105" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">3
+      <animate attributeName="x"
+        keyTimes="0;   0.2; 0.4; 0.6; 0.8; 1"
+        values  ="65; 125; 125; 125; 185; 185"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0 0 1 1; 0.4 0 0.2 1; 0.4 0 0.2 1; 0 0 1 1"/>
+    </text>
+  </g>
+
+  <!-- value=1: x trajectory 100, 40, 40, 40, 40, 40 -->
+  <g>
+    <rect width="50" height="30" y="170" fill="#34d399" stroke="#065f46" stroke-width="1.5" rx="3">
+      <animate attributeName="x"
+        keyTimes="0;    0.2; 0.4; 0.6; 0.8; 1"
+        values  ="100; 40;  40;  40;  40;  40"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0 0 1 1; 0 0 1 1; 0 0 1 1; 0 0 1 1"/>
+    </rect>
+    <text y="165" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">1
+      <animate attributeName="x"
+        keyTimes="0;    0.2; 0.4; 0.6; 0.8; 1"
+        values  ="125; 65;  65;  65;  65;  65"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0 0 1 1; 0 0 1 1; 0 0 1 1; 0 0 1 1"/>
+    </text>
+  </g>
+
+  <!-- value=4: x trajectory 160, 160, 160, 220, 220, 220 -->
+  <g>
+    <rect width="50" height="120" y="80" fill="#ef4444" stroke="#7f1d1d" stroke-width="1.5" rx="3">
+      <animate attributeName="x"
+        keyTimes="0;    0.2; 0.4; 0.6; 0.8; 1"
+        values  ="160; 160; 160; 220; 220; 220"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0 0 1 1; 0 0 1 1; 0.4 0 0.2 1; 0 0 1 1; 0 0 1 1"/>
+    </rect>
+    <text y="75" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">4
+      <animate attributeName="x"
+        keyTimes="0;    0.2; 0.4; 0.6; 0.8; 1"
+        values  ="185; 185; 185; 245; 245; 245"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0 0 1 1; 0 0 1 1; 0.4 0 0.2 1; 0 0 1 1; 0 0 1 1"/>
+    </text>
+  </g>
+
+  <!-- value=2: x trajectory 220, 220, 220, 160, 100, 100 -->
+  <g>
+    <rect width="50" height="60" y="140" fill="#3b82f6" stroke="#1e3a8a" stroke-width="1.5" rx="3">
+      <animate attributeName="x"
+        keyTimes="0;    0.2; 0.4; 0.6; 0.8; 1"
+        values  ="220; 220; 220; 160; 100; 100"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0 0 1 1; 0 0 1 1; 0.4 0 0.2 1; 0.4 0 0.2 1; 0 0 1 1"/>
+    </rect>
+    <text y="135" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">2
+      <animate attributeName="x"
+        keyTimes="0;    0.2; 0.4; 0.6; 0.8; 1"
+        values  ="245; 245; 245; 185; 125; 125"
+        dur="8s" repeatCount="indefinite" calcMode="spline"
+        keySplines="0 0 1 1; 0 0 1 1; 0.4 0 0.2 1; 0.4 0 0.2 1; 0 0 1 1"/>
+    </text>
+  </g>
+</svg>

--- a/examples/svg/heartbeat.svg
+++ b/examples/svg/heartbeat.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 320" font-family="-apple-system, system-ui, sans-serif">
+  <!--
+    ECG Heartbeat — synchronized 1.2s rhythm:
+      • Halo pulses with the beat
+      • Heart scales up on systole, settles on diastole (squash-and-stretch)
+      • ECG trace draws across the screen with the classic P-QRS-T waveform
+      • Spike particles burst outward at peak
+    Everything loops every 1.2s.
+  -->
+  <defs>
+    <radialGradient id="halo" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fda4af" stop-opacity="0.55"/>
+      <stop offset="55%" stop-color="#fb7185" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#e11d48" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="heartGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb7185"/>
+      <stop offset="100%" stop-color="#be123c"/>
+    </linearGradient>
+    <linearGradient id="ecgGlow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#22d3ee" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Dark backdrop with subtle grid -->
+  <rect width="600" height="320" fill="#0f172a"/>
+  <g stroke="#1e293b" stroke-width="1">
+    <line x1="0" y1="80"  x2="600" y2="80"/>
+    <line x1="0" y1="160" x2="600" y2="160"/>
+    <line x1="0" y1="240" x2="600" y2="240"/>
+    <line x1="100" y1="0" x2="100" y2="320"/>
+    <line x1="200" y1="0" x2="200" y2="320"/>
+    <line x1="300" y1="0" x2="300" y2="320"/>
+    <line x1="400" y1="0" x2="400" y2="320"/>
+    <line x1="500" y1="0" x2="500" y2="320"/>
+  </g>
+
+  <!-- BPM badge -->
+  <g transform="translate(530, 30)">
+    <rect x="-40" y="-14" width="80" height="28" rx="14" fill="#1e293b" stroke="#334155"/>
+    <text y="5" text-anchor="middle" fill="#22d3ee" font-size="12" font-weight="700" letter-spacing="1">50 BPM</text>
+  </g>
+
+  <!-- Halo, pulses with the heart -->
+  <circle cx="150" cy="160" r="80" fill="url(#halo)">
+    <animate attributeName="r" values="70;110;75;70" keyTimes="0;0.18;0.4;1"
+             dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.4;1;0.45;0.4" keyTimes="0;0.18;0.4;1"
+             dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Particles bursting outward at peak (8 directions) -->
+  <g fill="#fb7185">
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cx" values="150;220" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cx" values="150;205" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="160;110" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cy" values="160;90" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cx" values="150;95" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="160;110" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cx" values="150;80" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cx" values="150;95" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="160;210" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cy" values="160;230" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="150" cy="160" r="2.5">
+      <animate attributeName="cx" values="150;205" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="160;210" keyTimes="0;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;0" keyTimes="0;0.1;1" dur="1.2s"
+               begin="0.18s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- Heart with squash-and-stretch (anatomical heartbeat curve) -->
+  <g transform="translate(150 160)">
+    <path d="M0,40 C-60,0 -60,-50 -30,-50 C-15,-50 0,-35 0,-20 C0,-35 15,-50 30,-50 C60,-50 60,0 0,40 Z"
+          fill="url(#heartGrad)" filter="url(#glow)">
+      <animateTransform attributeName="transform" type="scale" additive="sum"
+        values="1;1.18;0.95;1.05;1"
+        keyTimes="0;0.12;0.22;0.35;1"
+        dur="1.2s" repeatCount="indefinite"
+        calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0.4 0 0.6 1; 0.4 0 0.2 1; 0.4 0 0.6 1"/>
+    </path>
+  </g>
+
+  <!-- ECG trace -->
+  <g transform="translate(250, 160)">
+    <!-- Baseline -->
+    <line x1="0" y1="0" x2="340" y2="0" stroke="#1e293b" stroke-width="1"/>
+
+    <!--
+      ECG waveform (classic P-QRS-T):
+        P:  small bump
+        QRS: sharp deep-then-tall-spike
+        T:  rounded bump
+      Total path length ≈ 460. We draw via dashoffset.
+    -->
+    <path id="ecg"
+          d="M0,0 L40,0
+             Q55,-6 70,0
+             L110,0
+             L120,4 L130,-50 L140,30 L150,0
+             L190,0
+             Q220,-12 250,0
+             L340,0"
+          fill="none"
+          stroke="#22d3ee"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          filter="url(#glow)"
+          stroke-dasharray="460"
+          stroke-dashoffset="460">
+      <animate attributeName="stroke-dashoffset"
+               from="460" to="-460"
+               dur="1.2s" repeatCount="indefinite"/>
+    </path>
+
+    <!-- Scanning playhead dot -->
+    <circle r="4" fill="#22d3ee" filter="url(#glow)">
+      <animateMotion dur="1.2s" repeatCount="indefinite">
+        <mpath href="#ecg"/>
+      </animateMotion>
+    </circle>
+  </g>
+</svg>

--- a/examples/svg/https-handshake.svg
+++ b/examples/svg/https-handshake.svg
@@ -1,0 +1,327 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 760">
+  <!--
+    Layout grid:
+      CLIENT_X = 140    SERVER_X = 860    CA_X = 500
+      ICON_Y   = 145    CA_Y     = 95
+      Lifelines: y 235 → 720
+      Step rows (label / arrow / desc):
+        Step 1 — title 260, arrow 290, desc 312
+        Step 2 — title 340, arrow 370, desc 392
+        Step 3 — title 422, desc 444, badge 466
+        Step 4 — title 502, arrow 532, desc 554
+        Step 5 — title 582, keys 612, desc 634
+        Step 6 — title 660, arrows 690 / 710
+      Insets: 140 px from edges (≥ 5%)
+  -->
+
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#1a2438"/>
+    </linearGradient>
+    <linearGradient id="clientGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+    <linearGradient id="serverGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#047857"/>
+    </linearGradient>
+    <linearGradient id="caGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fbbf24"/>
+      <stop offset="100%" stop-color="#b45309"/>
+    </linearGradient>
+    <radialGradient id="glowG" cx="0.5" cy="0.5">
+      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- background -->
+  <rect width="1000" height="760" fill="url(#bg)"/>
+
+  <!-- subtle grid -->
+  <g stroke="#1e293b" stroke-width="1" opacity="0.5">
+    <line x1="0" y1="220" x2="1000" y2="220"/>
+    <line x1="0" y1="730" x2="1000" y2="730"/>
+  </g>
+
+  <!-- title -->
+  <text x="500" y="40" text-anchor="middle" fill="#f1f5f9" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700">How HTTPS Works</text>
+  <text x="500" y="64" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="13">The TLS handshake and encrypted data exchange</text>
+
+  <!-- ===== CLIENT ===== -->
+  <g transform="translate(140, 145)">
+    <rect x="-45" y="-30" width="90" height="58" rx="5" fill="url(#clientGrad)" stroke="#93c5fd" stroke-width="1.5"/>
+    <rect x="-38" y="-23" width="76" height="44" rx="2" fill="#0f172a"/>
+    <rect x="-32" y="-16" width="50" height="2.5" fill="#60a5fa" opacity="0.8"/>
+    <rect x="-32" y="-10" width="36" height="2.5" fill="#60a5fa" opacity="0.5"/>
+    <rect x="-32" y="-4" width="44" height="2.5" fill="#60a5fa" opacity="0.5"/>
+    <rect x="-32" y="2" width="28" height="2.5" fill="#60a5fa" opacity="0.5"/>
+    <rect x="-32" y="8" width="40" height="2.5" fill="#60a5fa" opacity="0.5"/>
+    <rect x="-32" y="14" width="32" height="2.5" fill="#60a5fa" opacity="0.5"/>
+    <path d="M-58,33 L58,33 L48,42 L-48,42 Z" fill="#1e3a8a"/>
+    <text y="65" text-anchor="middle" fill="#f1f5f9" font-family="system-ui, sans-serif" font-size="15" font-weight="600">Client</text>
+    <text y="82" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">Web browser</text>
+  </g>
+
+  <!-- ===== SERVER ===== -->
+  <g transform="translate(860, 145)">
+    <rect x="-35" y="-38" width="70" height="72" rx="5" fill="url(#serverGrad)" stroke="#6ee7b7" stroke-width="1.5"/>
+    <g>
+      <rect x="-27" y="-30" width="54" height="11" rx="1.5" fill="#0f172a"/>
+      <circle cx="-20" cy="-24.5" r="2" fill="#34d399"/>
+      <circle cx="-13" cy="-24.5" r="2" fill="#34d399" opacity="0.4"/>
+      <rect x="10" y="-26" width="14" height="3" fill="#34d399" opacity="0.6"/>
+    </g>
+    <g>
+      <rect x="-27" y="-16" width="54" height="11" rx="1.5" fill="#0f172a"/>
+      <circle cx="-20" cy="-10.5" r="2" fill="#34d399"/>
+      <circle cx="-13" cy="-10.5" r="2" fill="#34d399" opacity="0.4"/>
+      <rect x="10" y="-12" width="14" height="3" fill="#34d399" opacity="0.6"/>
+    </g>
+    <g>
+      <rect x="-27" y="-2" width="54" height="11" rx="1.5" fill="#0f172a"/>
+      <circle cx="-20" cy="3.5" r="2" fill="#34d399"/>
+      <circle cx="-13" cy="3.5" r="2" fill="#34d399" opacity="0.4"/>
+      <rect x="10" y="2" width="14" height="3" fill="#34d399" opacity="0.6"/>
+    </g>
+    <g>
+      <rect x="-27" y="12" width="54" height="11" rx="1.5" fill="#0f172a"/>
+      <circle cx="-20" cy="17.5" r="2" fill="#34d399"/>
+      <circle cx="-13" cy="17.5" r="2" fill="#34d399" opacity="0.4"/>
+      <rect x="10" y="16" width="14" height="3" fill="#34d399" opacity="0.6"/>
+    </g>
+    <text y="65" text-anchor="middle" fill="#f1f5f9" font-family="system-ui, sans-serif" font-size="15" font-weight="600">Server</text>
+    <text y="82" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">example.com</text>
+  </g>
+
+  <!-- lifelines -->
+  <line x1="140" y1="235" x2="140" y2="720" stroke="#334155" stroke-width="1.5" stroke-dasharray="4 6"/>
+  <line x1="860" y1="235" x2="860" y2="720" stroke="#334155" stroke-width="1.5" stroke-dasharray="4 6"/>
+
+  <!-- ===== CA AUTHORITY (appears for step 3) ===== -->
+  <g transform="translate(500, 95)" opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="5.6s" dur="0.5s" fill="freeze"/>
+    <animate attributeName="opacity" from="1" to="0.25" begin="7.6s" dur="0.6s" fill="freeze"/>
+    <path d="M0,-26 L22,-18 L22,5 Q22,22 0,30 Q-22,22 -22,5 L-22,-18 Z" fill="url(#caGrad)" stroke="#fcd34d" stroke-width="1.5"/>
+    <text y="3" text-anchor="middle" fill="#0f172a" font-family="system-ui, sans-serif" font-size="11" font-weight="800">CA</text>
+    <text y="48" text-anchor="middle" fill="#fbbf24" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Trusted Authority</text>
+  </g>
+
+  <!-- =========================================================
+       STEP 1 — ClientHello
+       ========================================================= -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="1s" dur="0.4s" fill="freeze"/>
+    <!-- step number badge -->
+    <g transform="translate(50, 286)">
+      <circle r="11" fill="#1e3a8a" stroke="#60a5fa" stroke-width="1.5"/>
+      <text y="4" text-anchor="middle" fill="#dbeafe" font-family="system-ui, sans-serif" font-size="12" font-weight="700">1</text>
+    </g>
+    <text x="500" y="260" text-anchor="middle" fill="#93c5fd" font-family="system-ui, sans-serif" font-size="14" font-weight="700">ClientHello</text>
+    <!-- arrow -->
+    <line x1="162" y1="290" x2="836" y2="290" stroke="#60a5fa" stroke-width="2" opacity="0.35"/>
+    <polygon points="844,290 832,284 832,296" fill="#60a5fa" opacity="0.5"/>
+    <text x="500" y="312" text-anchor="middle" fill="#cbd5e1" font-family="system-ui, sans-serif" font-size="11">TLS version • Supported cipher suites • Client random number</text>
+  </g>
+  <!-- packet 1 -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="1.5s" dur="0.2s" fill="freeze"/>
+    <animate attributeName="opacity" from="1" to="0" begin="3.1s" dur="0.25s" fill="freeze"/>
+    <g>
+      <rect x="-26" y="-10" width="52" height="20" rx="3" fill="#3b82f6" stroke="#bfdbfe" stroke-width="1"/>
+      <text y="4" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="10" font-weight="700">HELLO</text>
+      <animateMotion dur="1.6s" begin="1.5s" fill="freeze" path="M162,290 L832,290"/>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       STEP 2 — ServerHello + Certificate
+       ========================================================= -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="3.2s" dur="0.4s" fill="freeze"/>
+    <g transform="translate(50, 366)">
+      <circle r="11" fill="#064e3b" stroke="#34d399" stroke-width="1.5"/>
+      <text y="4" text-anchor="middle" fill="#d1fae5" font-family="system-ui, sans-serif" font-size="12" font-weight="700">2</text>
+    </g>
+    <text x="500" y="340" text-anchor="middle" fill="#6ee7b7" font-family="system-ui, sans-serif" font-size="14" font-weight="700">ServerHello + Certificate</text>
+    <line x1="838" y1="370" x2="164" y2="370" stroke="#34d399" stroke-width="2" opacity="0.35"/>
+    <polygon points="156,370 168,364 168,376" fill="#34d399" opacity="0.5"/>
+    <text x="500" y="392" text-anchor="middle" fill="#cbd5e1" font-family="system-ui, sans-serif" font-size="11">Chosen cipher • Server random • Certificate containing public key</text>
+  </g>
+  <!-- packet 2 - certificate -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="3.7s" dur="0.2s" fill="freeze"/>
+    <animate attributeName="opacity" from="1" to="0" begin="5.3s" dur="0.25s" fill="freeze"/>
+    <g>
+      <!-- envelope shape -->
+      <rect x="-28" y="-12" width="56" height="24" rx="3" fill="#10b981" stroke="#a7f3d0" stroke-width="1"/>
+      <!-- ribbon seal -->
+      <circle cx="-17" cy="0" r="4" fill="#fbbf24" stroke="#fde68a" stroke-width="0.5"/>
+      <text x="6" y="3.5" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="9" font-weight="700">CERT</text>
+      <animateMotion dur="1.6s" begin="3.7s" fill="freeze" path="M838,370 L164,370"/>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       STEP 3 — Verify certificate with CA
+       ========================================================= -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="5.6s" dur="0.4s" fill="freeze"/>
+    <g transform="translate(50, 448)">
+      <circle r="11" fill="#78350f" stroke="#fbbf24" stroke-width="1.5"/>
+      <text y="4" text-anchor="middle" fill="#fef3c7" font-family="system-ui, sans-serif" font-size="12" font-weight="700">3</text>
+    </g>
+    <text x="500" y="422" text-anchor="middle" fill="#fcd34d" font-family="system-ui, sans-serif" font-size="14" font-weight="700">Client verifies certificate</text>
+    <text x="500" y="444" text-anchor="middle" fill="#cbd5e1" font-family="system-ui, sans-serif" font-size="11">Checks the certificate is signed by a trusted Certificate Authority</text>
+    <!-- curved arrow from client up to CA -->
+    <path d="M155,225 Q300,140 478,108" fill="none" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="4 4" opacity="0.55"/>
+    <!-- verification check on client -->
+    <g transform="translate(140, 470)" opacity="0">
+      <animate attributeName="opacity" from="0" to="1" begin="6.7s" dur="0.3s" fill="freeze"/>
+      <circle r="13" fill="#22c55e"/>
+      <path d="M-6,0 L-2,5 L6,-5" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <text x="170" y="474" fill="#86efac" font-family="system-ui, sans-serif" font-size="11" font-weight="600" opacity="0">
+      <animate attributeName="opacity" from="0" to="1" begin="6.9s" dur="0.3s" fill="freeze"/>
+      Trusted
+    </text>
+  </g>
+
+  <!-- =========================================================
+       STEP 4 — Pre-master secret (encrypted with public key)
+       ========================================================= -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="7.6s" dur="0.4s" fill="freeze"/>
+    <g transform="translate(50, 528)">
+      <circle r="11" fill="#4c1d95" stroke="#a78bfa" stroke-width="1.5"/>
+      <text y="4" text-anchor="middle" fill="#ede9fe" font-family="system-ui, sans-serif" font-size="12" font-weight="700">4</text>
+    </g>
+    <text x="500" y="502" text-anchor="middle" fill="#c4b5fd" font-family="system-ui, sans-serif" font-size="14" font-weight="700">Pre-master secret exchange</text>
+    <line x1="162" y1="532" x2="836" y2="532" stroke="#a78bfa" stroke-width="2" opacity="0.35"/>
+    <polygon points="844,532 832,526 832,538" fill="#a78bfa" opacity="0.5"/>
+    <text x="500" y="554" text-anchor="middle" fill="#cbd5e1" font-family="system-ui, sans-serif" font-size="11">Encrypted with server's public key — only the server can decrypt it</text>
+  </g>
+  <!-- packet 4 - encrypted secret -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="8.1s" dur="0.2s" fill="freeze"/>
+    <animate attributeName="opacity" from="1" to="0" begin="9.7s" dur="0.25s" fill="freeze"/>
+    <g>
+      <rect x="-28" y="-11" width="56" height="22" rx="3" fill="#7c3aed" stroke="#ddd6fe" stroke-width="1"/>
+      <!-- mini lock -->
+      <g transform="translate(-16, 0)">
+        <rect x="-3.5" y="0" width="7" height="6" rx="1" fill="#fde68a"/>
+        <path d="M-2.5,0 L-2.5,-3 Q-2.5,-5.5 0,-5.5 Q2.5,-5.5 2.5,-3 L2.5,0" fill="none" stroke="#fde68a" stroke-width="1.2"/>
+      </g>
+      <text x="6" y="3.5" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="9" font-weight="700">SECRET</text>
+      <animateMotion dur="1.6s" begin="8.1s" fill="freeze" path="M162,532 L832,532"/>
+    </g>
+  </g>
+
+  <!-- =========================================================
+       STEP 5 — Session key derived on both sides
+       ========================================================= -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="9.7s" dur="0.4s" fill="freeze"/>
+    <g transform="translate(50, 608)">
+      <circle r="11" fill="#14532d" stroke="#22c55e" stroke-width="1.5"/>
+      <text y="4" text-anchor="middle" fill="#dcfce7" font-family="system-ui, sans-serif" font-size="12" font-weight="700">5</text>
+    </g>
+    <text x="500" y="582" text-anchor="middle" fill="#86efac" font-family="system-ui, sans-serif" font-size="14" font-weight="700">Session key derived</text>
+
+    <!-- pulse from each side -->
+    <circle cx="140" cy="145" r="40" fill="url(#glowG)" opacity="0">
+      <animate attributeName="opacity" from="0.9" to="0" begin="9.9s" dur="1.2s" fill="freeze"/>
+      <animate attributeName="r" from="30" to="75" begin="9.9s" dur="1.2s" fill="freeze"/>
+    </circle>
+    <circle cx="860" cy="145" r="40" fill="url(#glowG)" opacity="0">
+      <animate attributeName="opacity" from="0.9" to="0" begin="9.9s" dur="1.2s" fill="freeze"/>
+      <animate attributeName="r" from="30" to="75" begin="9.9s" dur="1.2s" fill="freeze"/>
+    </circle>
+
+    <!-- key on client side -->
+    <g transform="translate(190, 608)" opacity="0">
+      <animate attributeName="opacity" from="0" to="1" begin="10.2s" dur="0.4s" fill="freeze"/>
+      <circle cx="0" cy="0" r="6" fill="none" stroke="#fbbf24" stroke-width="2"/>
+      <circle cx="0" cy="0" r="2" fill="#fbbf24"/>
+      <line x1="6" y1="0" x2="22" y2="0" stroke="#fbbf24" stroke-width="2"/>
+      <line x1="16" y1="0" x2="16" y2="5" stroke="#fbbf24" stroke-width="2"/>
+      <line x1="21" y1="0" x2="21" y2="4" stroke="#fbbf24" stroke-width="2"/>
+    </g>
+    <!-- key on server side -->
+    <g transform="translate(810, 608)" opacity="0">
+      <animate attributeName="opacity" from="0" to="1" begin="10.2s" dur="0.4s" fill="freeze"/>
+      <line x1="-22" y1="0" x2="-6" y2="0" stroke="#fbbf24" stroke-width="2"/>
+      <line x1="-16" y1="0" x2="-16" y2="5" stroke="#fbbf24" stroke-width="2"/>
+      <line x1="-21" y1="0" x2="-21" y2="4" stroke="#fbbf24" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="none" stroke="#fbbf24" stroke-width="2"/>
+      <circle cx="0" cy="0" r="2" fill="#fbbf24"/>
+    </g>
+    <!-- equals badge in middle -->
+    <g transform="translate(500, 608)" opacity="0">
+      <animate attributeName="opacity" from="0" to="1" begin="10.4s" dur="0.4s" fill="freeze"/>
+      <rect x="-46" y="-13" width="92" height="26" rx="13" fill="#15803d" stroke="#86efac" stroke-width="1"/>
+      <text y="4" text-anchor="middle" fill="#f0fdf4" font-family="system-ui, sans-serif" font-size="11" font-weight="700">SAME KEY</text>
+    </g>
+
+    <text x="500" y="640" text-anchor="middle" fill="#cbd5e1" font-family="system-ui, sans-serif" font-size="11">Both sides derive the same symmetric session key — fast and secret</text>
+  </g>
+
+  <!-- =========================================================
+       STEP 6 — Encrypted application data
+       ========================================================= -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="11.2s" dur="0.5s" fill="freeze"/>
+    <g transform="translate(50, 690)">
+      <circle r="11" fill="#064e3b" stroke="#10b981" stroke-width="1.5"/>
+      <text y="4" text-anchor="middle" fill="#d1fae5" font-family="system-ui, sans-serif" font-size="12" font-weight="700">6</text>
+    </g>
+    <text x="500" y="668" text-anchor="middle" fill="#6ee7b7" font-family="system-ui, sans-serif" font-size="15" font-weight="700">Secure encrypted communication</text>
+    <text x="500" y="688" text-anchor="middle" fill="#cbd5e1" font-family="system-ui, sans-serif" font-size="11">All application data is now encrypted with the shared session key</text>
+
+    <!-- channel lines -->
+    <line x1="162" y1="708" x2="838" y2="708" stroke="#10b981" stroke-width="1" opacity="0.25" stroke-dasharray="6 4"/>
+    <line x1="162" y1="724" x2="838" y2="724" stroke="#10b981" stroke-width="1" opacity="0.25" stroke-dasharray="6 4"/>
+  </g>
+
+  <!-- encrypted packets looping (start after handshake completes) -->
+  <g opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="11.7s" dur="0.4s" fill="freeze"/>
+    <!-- request from client to server -->
+    <g>
+      <g>
+        <rect x="-26" y="-9" width="52" height="18" rx="9" fill="#059669" stroke="#a7f3d0" stroke-width="1"/>
+        <!-- tiny lock -->
+        <g transform="translate(-15, 0)">
+          <rect x="-3" y="-1" width="6" height="5" rx="0.8" fill="white"/>
+          <path d="M-2.2,-1 L-2.2,-3.5 Q-2.2,-5.5 0,-5.5 Q2.2,-5.5 2.2,-3.5 L2.2,-1" fill="none" stroke="white" stroke-width="1.2"/>
+        </g>
+        <text x="6" y="3" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="9" font-weight="700">DATA</text>
+        <animateMotion dur="2.4s" begin="11.7s" repeatCount="indefinite" path="M162,708 L838,708"/>
+      </g>
+    </g>
+    <!-- response from server to client (delayed) -->
+    <g>
+      <g>
+        <rect x="-26" y="-9" width="52" height="18" rx="9" fill="#059669" stroke="#a7f3d0" stroke-width="1"/>
+        <g transform="translate(-15, 0)">
+          <rect x="-3" y="-1" width="6" height="5" rx="0.8" fill="white"/>
+          <path d="M-2.2,-1 L-2.2,-3.5 Q-2.2,-5.5 0,-5.5 Q2.2,-5.5 2.2,-3.5 L2.2,-1" fill="none" stroke="white" stroke-width="1.2"/>
+        </g>
+        <text x="6" y="3" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="9" font-weight="700">DATA</text>
+        <animateMotion dur="2.4s" begin="12.9s" repeatCount="indefinite" path="M838,724 L162,724"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Final "secure" badge near client -->
+  <g transform="translate(140, 105)" opacity="0">
+    <animate attributeName="opacity" from="0" to="1" begin="11.5s" dur="0.5s" fill="freeze"/>
+    <circle r="13" fill="#16a34a" stroke="#bbf7d0" stroke-width="1.5"/>
+    <g transform="translate(0, 1)">
+      <rect x="-4" y="-1" width="8" height="7" rx="1" fill="white"/>
+      <path d="M-3,-1 L-3,-4 Q-3,-7 0,-7 Q3,-7 3,-4 L3,-1" fill="none" stroke="white" stroke-width="1.5"/>
+    </g>
+  </g>
+</svg>

--- a/examples/svg/load-balancer.svg
+++ b/examples/svg/load-balancer.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 280" font-family="-apple-system, system-ui, sans-serif">
+  <!--
+    Round-robin load balancer with 6 requests on a continuous loop.
+
+    Each request runs on its own 6s cycle (repeatCount="indefinite") with a
+    1s begin offset (so 6 staggered requests fill the 6s window):
+      • animateMotion uses keyTimes/keyPoints to traverse the full path in
+        the first 33% of the cycle (2s of motion), then "park" at the end
+        position for the remaining 4s.
+      • Opacity fades in at the start, holds during motion, fades out at the
+        end of the motion, then stays invisible while parked.
+    Round-robin distribution: req1→s1, req2→s2, req3→s3, req4→s1, …
+  -->
+  <defs>
+    <path id="path-s1" d="M 40,140 L 200,140 L 220,140 C 260,140 260,70 320,70 L 380,70"/>
+    <path id="path-s2" d="M 40,140 L 200,140 L 220,140 C 260,140 260,140 320,140 L 380,140"/>
+    <path id="path-s3" d="M 40,140 L 200,140 L 220,140 C 260,140 260,210 320,210 L 380,210"/>
+
+    <radialGradient id="serverGlow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="480" height="280" fill="#f8fafc"/>
+
+  <text x="240" y="26" text-anchor="middle" font-size="14" font-weight="600" fill="#1e293b">
+    Round-Robin Load Balancer
+  </text>
+
+  <g>
+    <rect x="10" y="110" width="60" height="60" rx="8" fill="#fff" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="40" y="135" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">Clients</text>
+    <circle cx="25" cy="150" r="3" fill="#64748b"/>
+    <circle cx="40" cy="155" r="3" fill="#64748b"/>
+    <circle cx="55" cy="150" r="3" fill="#64748b"/>
+  </g>
+
+  <use href="#path-s1" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-dasharray="3 3"/>
+  <use href="#path-s2" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-dasharray="3 3"/>
+  <use href="#path-s3" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-dasharray="3 3"/>
+
+  <g>
+    <rect x="180" y="110" width="80" height="60" rx="8" fill="#1e293b" stroke="#0f172a" stroke-width="1.5"/>
+    <text x="220" y="135" text-anchor="middle" font-size="11" font-weight="600" fill="#f1f5f9">Load</text>
+    <text x="220" y="150" text-anchor="middle" font-size="11" font-weight="600" fill="#f1f5f9">Balancer</text>
+    <!-- Pulse ticks at 1s to mark each incoming request (matches stagger). -->
+    <rect x="180" y="110" width="80" height="60" rx="8" fill="none"
+          stroke="#3b82f6" stroke-width="3" opacity="0">
+      <animate attributeName="opacity" values="0;0.9;0" dur="1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+
+  <g>
+    <circle cx="410" cy="70" r="36" fill="url(#serverGlow)"/>
+    <rect x="380" y="50" width="60" height="40" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="2"/>
+    <text x="410" y="74" text-anchor="middle" font-size="11" font-weight="600" fill="#1e3a8a">Server 1</text>
+
+    <circle cx="410" cy="140" r="36" fill="url(#serverGlow)"/>
+    <rect x="380" y="120" width="60" height="40" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="2"/>
+    <text x="410" y="144" text-anchor="middle" font-size="11" font-weight="600" fill="#1e3a8a">Server 2</text>
+
+    <circle cx="410" cy="210" r="36" fill="url(#serverGlow)"/>
+    <rect x="380" y="190" width="60" height="40" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="2"/>
+    <text x="410" y="214" text-anchor="middle" font-size="11" font-weight="600" fill="#1e3a8a">Server 3</text>
+  </g>
+
+  <g opacity="0">
+    <circle r="7" fill="#ef4444" stroke="#7f1d1d" stroke-width="1"/>
+    <animateMotion dur="6s" begin="0s" repeatCount="indefinite" rotate="auto"
+                   keyTimes="0; 0.33; 1" keyPoints="0; 1; 1" calcMode="linear">
+      <mpath href="#path-s1"/>
+    </animateMotion>
+    <animate attributeName="opacity" values="0;1;1;0;0"
+             keyTimes="0; 0.04; 0.30; 0.34; 1"
+             dur="6s" begin="0s" repeatCount="indefinite"/>
+  </g>
+
+  <g opacity="0">
+    <circle r="7" fill="#22c55e" stroke="#14532d" stroke-width="1"/>
+    <animateMotion dur="6s" begin="1s" repeatCount="indefinite" rotate="auto"
+                   keyTimes="0; 0.33; 1" keyPoints="0; 1; 1" calcMode="linear">
+      <mpath href="#path-s2"/>
+    </animateMotion>
+    <animate attributeName="opacity" values="0;1;1;0;0"
+             keyTimes="0; 0.04; 0.30; 0.34; 1"
+             dur="6s" begin="1s" repeatCount="indefinite"/>
+  </g>
+
+  <g opacity="0">
+    <circle r="7" fill="#a855f7" stroke="#581c87" stroke-width="1"/>
+    <animateMotion dur="6s" begin="2s" repeatCount="indefinite" rotate="auto"
+                   keyTimes="0; 0.33; 1" keyPoints="0; 1; 1" calcMode="linear">
+      <mpath href="#path-s3"/>
+    </animateMotion>
+    <animate attributeName="opacity" values="0;1;1;0;0"
+             keyTimes="0; 0.04; 0.30; 0.34; 1"
+             dur="6s" begin="2s" repeatCount="indefinite"/>
+  </g>
+
+  <g opacity="0">
+    <circle r="7" fill="#f97316" stroke="#7c2d12" stroke-width="1"/>
+    <animateMotion dur="6s" begin="3s" repeatCount="indefinite" rotate="auto"
+                   keyTimes="0; 0.33; 1" keyPoints="0; 1; 1" calcMode="linear">
+      <mpath href="#path-s1"/>
+    </animateMotion>
+    <animate attributeName="opacity" values="0;1;1;0;0"
+             keyTimes="0; 0.04; 0.30; 0.34; 1"
+             dur="6s" begin="3s" repeatCount="indefinite"/>
+  </g>
+
+  <g opacity="0">
+    <circle r="7" fill="#06b6d4" stroke="#164e63" stroke-width="1"/>
+    <animateMotion dur="6s" begin="4s" repeatCount="indefinite" rotate="auto"
+                   keyTimes="0; 0.33; 1" keyPoints="0; 1; 1" calcMode="linear">
+      <mpath href="#path-s2"/>
+    </animateMotion>
+    <animate attributeName="opacity" values="0;1;1;0;0"
+             keyTimes="0; 0.04; 0.30; 0.34; 1"
+             dur="6s" begin="4s" repeatCount="indefinite"/>
+  </g>
+
+  <g opacity="0">
+    <circle r="7" fill="#ec4899" stroke="#831843" stroke-width="1"/>
+    <animateMotion dur="6s" begin="5s" repeatCount="indefinite" rotate="auto"
+                   keyTimes="0; 0.33; 1" keyPoints="0; 1; 1" calcMode="linear">
+      <mpath href="#path-s3"/>
+    </animateMotion>
+    <animate attributeName="opacity" values="0;1;1;0;0"
+             keyTimes="0; 0.04; 0.30; 0.34; 1"
+             dur="6s" begin="5s" repeatCount="indefinite"/>
+  </g>
+</svg>

--- a/examples/svg/motion-path.svg
+++ b/examples/svg/motion-path.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200">
+  <!-- Element following a bezier path via <animateMotion> + <mpath>. -->
+  <defs>
+    <path id="track"
+          d="M 30,100
+             C 80,20  140,180  200,100
+             S 320,20  370,100"/>
+  </defs>
+
+  <!-- Visible track -->
+  <use href="#track" stroke="#cbd5e1" stroke-width="2" fill="none" stroke-dasharray="4 4"/>
+
+  <!-- Travelling element. rotate="auto" keeps it tangent to the curve. -->
+  <g>
+    <polygon points="-10,-6 12,0 -10,6" fill="#3b82f6"/>
+    <circle r="4" fill="#fff"/>
+    <animateMotion dur="4s" repeatCount="indefinite" rotate="auto">
+      <mpath href="#track"/>
+    </animateMotion>
+  </g>
+
+  <!-- Endpoints -->
+  <circle cx="30"  cy="100" r="5" fill="#22c55e"/>
+  <circle cx="370" cy="100" r="5" fill="#ef4444"/>
+</svg>

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -14,7 +14,7 @@ SKILLS_DIR="$PROJECT_ROOT/skills"
 # Note: All skill scripts are called with --no-browser flag below
 
 # Create docs/examples directories
-mkdir -p "$DOCS_DIR/examples"/{csv,json,markdown,mermaid,diff,d3,threejs,leaflet,plan}
+mkdir -p "$DOCS_DIR/examples"/{csv,json,markdown,mermaid,diff,d3,threejs,leaflet,plan,svg}
 
 echo "Generating documentation examples..."
 
@@ -111,6 +111,13 @@ echo "Leaflet Examples:"
 generate_example "preview-leaflet" "$EXAMPLES_DIR/leaflet/world-cities.leaflet" "$DOCS_DIR/examples/leaflet" "world-cities.html"
 generate_example "preview-leaflet" "$EXAMPLES_DIR/leaflet/everest-trail.leaflet" "$DOCS_DIR/examples/leaflet" "everest-trail.html"
 generate_example "preview-leaflet" "$EXAMPLES_DIR/leaflet/longest-trails.leaflet" "$DOCS_DIR/examples/leaflet" "longest-trails.html"
+
+echo ""
+echo "SVG Examples:"
+generate_example "preview-svg" "$EXAMPLES_DIR/svg/heartbeat.svg" "$DOCS_DIR/examples/svg" "heartbeat.html"
+generate_example "preview-svg" "$EXAMPLES_DIR/svg/motion-path.svg" "$DOCS_DIR/examples/svg" "motion-path.html"
+generate_example "preview-svg" "$EXAMPLES_DIR/svg/bubble-sort.svg" "$DOCS_DIR/examples/svg" "bubble-sort.html"
+generate_example "preview-svg" "$EXAMPLES_DIR/svg/load-balancer.svg" "$DOCS_DIR/examples/svg" "load-balancer.html"
 
 echo ""
 echo "Documentation examples generated successfully!"

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -118,6 +118,7 @@ generate_example "preview-svg" "$EXAMPLES_DIR/svg/heartbeat.svg" "$DOCS_DIR/exam
 generate_example "preview-svg" "$EXAMPLES_DIR/svg/motion-path.svg" "$DOCS_DIR/examples/svg" "motion-path.html"
 generate_example "preview-svg" "$EXAMPLES_DIR/svg/bubble-sort.svg" "$DOCS_DIR/examples/svg" "bubble-sort.html"
 generate_example "preview-svg" "$EXAMPLES_DIR/svg/load-balancer.svg" "$DOCS_DIR/examples/svg" "load-balancer.html"
+generate_example "preview-svg" "$EXAMPLES_DIR/svg/https-handshake.svg" "$DOCS_DIR/examples/svg" "https-handshake.html"
 
 echo ""
 echo "Documentation examples generated successfully!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,6 +30,7 @@ AVAILABLE_SKILLS=(
     "preview-d3"
     "preview-threejs"
     "preview-leaflet"
+    "preview-svg"
 )
 
 log() {
@@ -69,6 +70,7 @@ SKILLS:
   preview-d3         Preview D3.js visualizations
   preview-threejs    Preview Three.js 3D visualizations
   preview-leaflet    Preview Leaflet maps
+  preview-svg        Preview SVG animations (SMIL, CSS keyframes, JS)
 
 EXAMPLES:
   # Interactive mode - select skills

--- a/skills/preview-svg/SKILL.md
+++ b/skills/preview-svg/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: preview-svg
+description: Render and preview SVG animations in the browser with play/pause, timeline scrubbing, zoom & pan, code view, and export. Use when explaining a concept visually with an animated SVG (SMIL, CSS keyframes, or inline-JS), prototyping path-draw / morph / motion-path effects, or iterating on an animated icon, logo, or diagram. Triggers on "animated SVG", "explain visually", "SMIL", "path morph", "animateMotion", "animate this concept".
+user-invocable: true
+commands:
+  - preview-svg
+---
+
+# Preview SVG Animation Skill
+
+Render any animated SVG in a controllable browser preview — built for explaining
+hard concepts visually. Supports SMIL (`<animate>`, `<animateTransform>`,
+`<animateMotion>`), CSS keyframes/transitions inside `<style>`, and inline JS.
+
+## Agent Usage
+
+When the user asks to visualize or explain something with an animated SVG, write
+the SVG content and pipe it to the script. The renderer parses the SVG, wires up
+animation controls, and **automatically opens the result in the browser** — do
+NOT open the file manually.
+
+```bash
+# Pipe SVG content
+cat heartbeat.svg | ./run.sh
+
+# Or from a file
+./run.sh diagram.svg
+
+# Skip browser, just emit path (useful for batch generation)
+./run.sh diagram.svg --no-browser
+```
+
+## Usage
+
+```bash
+# Preview an SVG file
+/preview-svg heartbeat.svg
+
+# Pipe SVG content (preferred for temporary explainers)
+cat animation.svg | /preview-svg
+echo '<svg ...>...</svg>' | /preview-svg
+```
+
+## Built-in Controls
+
+- **Play / Pause** — pauses all SMIL via `pauseAnimations()` and CSS via
+  `animation-play-state`.
+- **Restart** — `setCurrentTime(0)` for SMIL + reapplies CSS animations.
+- **Timeline scrub** — drag the slider to seek; live updates while playing
+  (SMIL only; CSS-only animations don't expose seeking).
+- **Zoom & Pan** — mouse wheel to zoom (0.2x–20x), drag to pan via viewBox
+  manipulation. Reset button restores original framing.
+- **Code view** — toggle to inspect the source SVG.
+- **Export SVG** — download the current SVG (preserves any runtime changes).
+
+## When to Use
+
+Activate when the user wants to:
+
+- Explain a concept visually (gradient descent, request flow, data structures)
+- Animate an icon or logo (path-draw, morph, hamburger↔X)
+- Show motion along a path (`<animateMotion>` + `<mpath>`)
+- Prototype loading spinners, progress rings, ambient backgrounds
+- Build a self-contained, script-free interactive SVG (SMIL `begin="el.click"`)
+
+For **interactive D3 / JS-driven** visualizations, prefer `preview-d3`. For
+**3D / WebGL** scenes, use `preview-threejs`. For **flowcharts / sequence
+diagrams**, use `preview-mermaid`.
+
+## Authoring Guide
+
+### Minimal animated SVG (SMIL)
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="10" fill="crimson">
+    <animate attributeName="r" values="10;20;10" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+</svg>
+```
+
+### Path-draw (stroke-dashoffset)
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    .draw {
+      stroke-dasharray: 200;
+      stroke-dashoffset: 200;
+      animation: draw 2s ease-in-out forwards;
+    }
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+  </style>
+  <path class="draw" d="M10,50 Q50,10 90,50 T90,90"
+        fill="none" stroke="#3b82f6" stroke-width="3"/>
+</svg>
+```
+
+For accurate dasharray values, set `pathLength="100"` on the path and use
+`stroke-dasharray="100"` — then dashoffset works in percent.
+
+### Shape morph (SMIL `animate` on `d`)
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <path d="M10,10 L90,10 L90,90 L10,90 Z" fill="#3b82f6">
+    <animate attributeName="d" dur="2s" repeatCount="indefinite"
+             values="M10,10 L90,10 L90,90 L10,90 Z;
+                     M50,10 L90,50 L50,90 L10,50 Z;
+                     M10,10 L90,10 L90,90 L10,90 Z"/>
+  </path>
+</svg>
+```
+
+**Critical**: morph pairs must have **the same number of path commands of the
+same types** — otherwise the browser cannot interpolate. Trace both shapes with
+the same anchor count in the same winding direction.
+
+### Motion along a path
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <path id="track" d="M20,100 Q60,20 100,100 T180,100" fill="none" stroke="#ddd"/>
+  <circle r="6" fill="#3b82f6">
+    <animateMotion dur="3s" repeatCount="indefinite" rotate="auto">
+      <mpath href="#track"/>
+    </animateMotion>
+  </circle>
+</svg>
+```
+
+`rotate="auto"` keeps the element tangent to the curve. Use `auto-reverse`
+to flip 180°.
+
+### Staggered entrance (delays)
+
+Increment `begin` by ~0.3s per element for a smooth cascade:
+
+```xml
+<g opacity="0">
+  <rect width="100" height="24" rx="12" fill="#4a4a6a"/>
+  <animate attributeName="opacity" from="0" to="1" dur="0.5s" begin="0.3s" fill="freeze"/>
+</g>
+<g opacity="0">
+  <rect width="100" height="24" rx="12" fill="#4a4a6a"/>
+  <animate attributeName="opacity" from="0" to="1" dur="0.5s" begin="0.6s" fill="freeze"/>
+</g>
+```
+
+`fill="freeze"` keeps the final state; without it, elements revert.
+
+### Click-driven (no JS)
+
+```xml
+<rect id="box" width="40" height="40" fill="#3b82f6">
+  <animate attributeName="fill" begin="box.click" dur="0.3s"
+           to="#22c55e" fill="freeze"/>
+</rect>
+```
+
+Chain animations with `begin="otherAnim.end + 0.2s"` for state machines.
+
+## CSS vs SMIL — Choosing
+
+| Goal                                 | Use  | Why                            |
+| ------------------------------------ | ---- | ------------------------------ |
+| `opacity`, color loops               | CSS  | GPU-accelerated, lower battery |
+| `transform` (rotate/scale/translate) | CSS  | Composited on GPU              |
+| `:hover` / `:focus` states           | CSS  | SMIL can't react to these      |
+| Path morphing (`d` attribute)        | SMIL | CSS can't animate `d` portably |
+| `viewBox` animation                  | SMIL | No CSS equivalent              |
+| Click-triggered sequences            | SMIL | `begin="el.click"` without JS  |
+| Following a bezier path              | SMIL | `<animateMotion>` + `<mpath>`  |
+
+Default: **CSS for what it can reach, SMIL for the rest.**
+
+## Animation Theory — Quick Reference
+
+- **Easing**: `ease-in` = slow start (anticipation), `ease-out` = soft landing
+  (most natural for UI), `ease-in-out` for both ends, linear for continuous
+  motion (spinners, loops).
+- **Duration**: micro-interactions 150–300ms; UI transitions 300–500ms;
+  storytelling animations 1–3s; ambient loops 3s+.
+- **Stagger**: 50–100ms between items for lists, 200–400ms for heavy elements
+  like cards or sections.
+- **Reduced motion**: wrap non-essential motion in
+  `@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }`.
+- **Don't animate**: layout properties (`width`, `height`, `top`, `left`) — use
+  `transform` and `opacity`, the only two cheap properties.
+
+## Stage Behavior
+
+The preview stage:
+
+- Resizes the SVG to `max-width: 90%; max-height: 90%` of the viewport
+- Shows a checkerboard background so transparency is visible
+- Strips `width`/`height` attrs on the root SVG and relies on `viewBox`
+- Wraps fragments without an `<svg>` root in a default 400×400 SVG
+
+## Stats Header
+
+The header shows: `<lines> lines • <chars> chars • <features> • ~<duration>s`
+where features is auto-detected from the content (`SMIL`, `CSS anim`, `JS`, or
+`static`) and duration is estimated by parsing `dur` and `begin` attributes.
+
+## Troubleshooting
+
+### Animation doesn't play
+
+- Confirm `<animate>` is **inside** the element it targets, not a sibling.
+- For CSS, confirm `@keyframes name` matches `animation: name ...;`.
+- Open devtools console — SMIL parse errors are silent in the DOM.
+
+### Path morph jumps instead of tweening
+
+- Source and target `d` paths must have the **same command sequence**. Convert
+  both to a normalized form (e.g., all cubic beziers).
+
+### Scrubber doesn't move
+
+- Scrubbing requires SMIL (`setCurrentTime` is an SVG API). Pure CSS animations
+  can be paused but not seeked.
+
+### SVG is too small / too large
+
+- Remove `width`/`height` attributes and rely on `viewBox`; the renderer strips
+  them anyway so the stage controls sizing.
+
+## Output
+
+```
+.preview-skills/svg/{filename}.html
+```
+
+## Learn More
+
+- [SMIL 3.0 spec (W3C)](https://www.w3.org/TR/SMIL3/)
+- [MDN: SVG animation with SMIL](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/SVG_animation_with_SMIL)
+- [CSS-Tricks: SVG line animation guide](https://css-tricks.com/svg-line-animation-works/)

--- a/skills/preview-svg/SKILL.md
+++ b/skills/preview-svg/SKILL.md
@@ -174,6 +174,96 @@ Chain animations with `begin="otherAnim.end + 0.2s"` for state machines.
 
 Default: **CSS for what it can reach, SMIL for the rest.**
 
+## Layout & Composition — Avoid Overlap Bugs
+
+The most common authoring failures aren't animation bugs — they're layout
+collisions: an icon on top of text, a label that runs into the next column,
+a decorative badge floating disconnected from its row. Follow these rules
+to ship clean SVGs the first time.
+
+### 1. Declare a grid before placing anything
+
+At the top of the SVG (in a comment or in `<defs>`), declare your row Y
+positions and column X positions as named coordinates. Place every element
+via `<g transform="translate(X,Y)">` referencing those names. Never
+free-position.
+
+```xml
+<!--
+  Lanes:  CLIENT_X=160   SERVER_X=720
+  Rows:   ROW1=60   ROW2=160   ROW3=260   ROW4=360
+  Gaps:   row gap 100, gutter 24, icon-to-text 12
+-->
+<g transform="translate(160, 60)">
+  <!-- ClientHello row content, anchored at (0,0) -->
+</g>
+```
+
+### 2. Reserve horizontal space for icons
+
+A 24×24 icon next to a text label needs **at least 12px gap** between them.
+A 14px-font text label is roughly `chars × 7px` wide. Compute the icon's
+position from the text's center, not from the row's center.
+
+**Wrong**: icon `cx=400`, text centered at `x=400` → icon sits on top of text.
+**Right**: text centered at `x=400`, icon at `cx = 400 - (charCount * 3.5) - 24`.
+
+### 3. Don't put emojis inside `<text>`
+
+Emoji rendering differs across OS/browser — sizing, baseline, and color
+are unpredictable. They break alignment and animation timing. Use proper
+SVG shapes for icons (paths, circles, gradients) or, if you must, give
+the emoji its **own** `<text>` with explicit position so it doesn't shift
+the surrounding label.
+
+```xml
+<!-- BAD: emoji shifts the rest of the text unpredictably -->
+<text>shared session key 🔑</text>
+
+<!-- OK: emoji is its own element with explicit position -->
+<text x="100">shared session key</text>
+<text x="280" font-size="18">🔑</text>
+
+<!-- BEST: real SVG icon, fully controlled -->
+<text x="100">shared session key</text>
+<g transform="translate(280, -10)"><!-- key icon path --></g>
+```
+
+### 4. One element, one row
+
+Decorations belong to one row only. Don't float a badge for row 2 next to
+row 3's content — readers can't tell which row owns it. If a step needs
+its own icon, build a self-contained `<g>` for that step with the icon
+inside its bounds.
+
+### 5. Leave breathing room at the edges
+
+The renderer fills the stage at 100%; nothing crops to the viewport.
+Inset content by **at least 5% of viewBox width** on each side so labels
+don't kiss the edge.
+
+### 6. Use a consistent text-anchor strategy per column
+
+Pick one of:
+
+- All labels in a column use `text-anchor="middle"` with `x` at the column center.
+- All labels in a column use `text-anchor="start"` with `x` at the column left.
+
+Mixing them within a column causes misalignment that compounds across rows.
+
+### Authoring checklist
+
+Before finalizing the SVG, mentally walk through:
+
+- [ ] Every text and icon position is declared via a `<g transform>` or
+      named coordinate (no magic numbers scattered through the file).
+- [ ] No `<text>` contains an emoji adjacent to other characters.
+- [ ] Every decoration is inside the `<g>` of the row it describes.
+- [ ] All labels in the same column share one `text-anchor` strategy.
+- [ ] Inset from viewBox edges is ≥ 5% on each side.
+- [ ] No two elements with `fill` or `stroke` overlap unless intentionally
+      layered (background → mid → foreground).
+
 ## Animation Theory — Quick Reference
 
 - **Easing**: `ease-in` = slow start (anticipation), `ease-out` = soft landing

--- a/skills/preview-svg/config.sh
+++ b/skills/preview-svg/config.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# SVG Animation Preview Skill Configuration
+
+# Skill metadata
+TOOL_NAME="svg"
+TOOL_TITLE_PREFIX="SVG Animation"
+DEFAULT_FILENAME="animation"
+FILE_EXTENSIONS=(".svg" ".svg.xml")
+DEFAULT_THEME="default"
+
+# Layout configuration
+LAYOUT_TYPE="full"
+BACKGROUND_COLOR="#ffffff"
+
+# No CDN libraries needed — SVG/SMIL/CSS animations run natively.
+CDN_SCRIPTS=()
+
+# CSS files
+STYLE_FILES=(
+    "templates/styles/layout.css"
+    "templates/styles/svg.css"
+)
+
+# Content is base64-encoded to safely transport arbitrary SVG markup
+# (including newlines, quotes, ampersands) into the rendered HTML.
+CONTENT_ENCODING="base64"
+NEEDS_USER_CODE_TEMPLATE=0
+
+# Renderer configuration. The renderer receives the encoded SVG content via
+# the substitution token below; stats (features, lines, chars) are computed
+# in the renderer at runtime from the decoded SVG so no extra plumbing is needed.
+RENDERER_FILE="templates/scripts/svg-renderer.js"
+RENDERER_VARS=("SVG_CONTENT_ENCODED")
+
+# Light input check — warn but don't fail if the payload looks non-SVG.
+validate_content() {
+    local content="$1"
+    if ! echo "$content" | grep -qiE '<svg|<\?xml|xmlns'; then
+        echo "Warning: Content does not look like SVG (no <svg> tag found). Rendering anyway." >&2
+    fi
+    return 0
+}

--- a/skills/preview-svg/lib/browser-utils.sh
+++ b/skills/preview-svg/lib/browser-utils.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+
+#===============================================================================
+# AUTO-GENERATED - DO NOT EDIT
+#===============================================================================
+# Source: src/core/lib/browser-utils.sh
+# To edit: Modify source file, then run: src/scripts/sync-skills.sh
+#===============================================================================
+
+
+# Browser Utilities Library
+# Functions for opening browsers and managing preview files
+
+# Preview output directory (project-local)
+readonly PREVIEW_DIR=".preview-skills"
+
+#######################################
+# Validate file path for security
+# Prevents path traversal and ensures file is in allowed locations
+# Arguments:
+#   $1 - File path to validate
+#   $2 - Optional base directory (defaults to current directory)
+# Environment:
+#   PREVIEW_ALLOW_EXTERNAL_FILES - Set to "1" to allow files outside base dir (default: 1)
+#   PREVIEW_ALLOW_SYMLINKS - Set to "1" to allow symlinks (default: 0)
+# Returns:
+#   Exit code 0 if valid, 1 if invalid
+#######################################
+validate_file_path() {
+    local file_path="$1"
+    local base_dir="${2:-.}"
+    local allow_external="${PREVIEW_ALLOW_EXTERNAL_FILES:-1}"
+    local allow_symlinks="${PREVIEW_ALLOW_SYMLINKS:-0}"
+
+    # Check if file exists
+    if [ ! -f "$file_path" ]; then
+        echo "Error: File not found: $file_path" >&2
+        return 1
+    fi
+
+    # Check if file is a symbolic link
+    if [ -L "$file_path" ]; then
+        if [ "$allow_symlinks" != "1" ]; then
+            echo "Error: Symbolic links are not allowed for security: $file_path" >&2
+            echo "Set PREVIEW_ALLOW_SYMLINKS=1 to override this restriction." >&2
+            return 1
+        else
+            echo "Warning: File is a symbolic link: $file_path" >&2
+        fi
+    fi
+
+    # Get absolute paths and validate location
+    if command -v realpath >/dev/null 2>&1; then
+        local abs_file
+        local abs_base
+
+        abs_file=$(realpath "$file_path" 2>/dev/null) || return 1
+        abs_base=$(realpath "$base_dir" 2>/dev/null) || abs_base="$base_dir"
+
+        # Check if file is under base directory (prevent path traversal)
+        if [[ "$abs_file" != "$abs_base"* ]]; then
+            if [ "$allow_external" != "1" ]; then
+                echo "Error: Access denied - file is outside allowed directory: $file_path" >&2
+                echo "File location: $abs_file" >&2
+                echo "Allowed base: $abs_base" >&2
+                echo "Set PREVIEW_ALLOW_EXTERNAL_FILES=1 to override this restriction." >&2
+                return 1
+            fi
+            # No warning when external files are explicitly allowed
+        fi
+    else
+        # Fallback: check for path traversal patterns when realpath is unavailable
+        # This is a basic check that catches common traversal attempts
+        if [[ "$file_path" == *".."* ]]; then
+            echo "Error: Path contains '..' which may indicate path traversal: $file_path" >&2
+            return 1
+        fi
+        # Check for absolute paths outside base when external files not allowed
+        if [ "$allow_external" != "1" ]; then
+            if [[ "$file_path" == /* ]] && [[ "$file_path" != "$base_dir"* ]]; then
+                echo "Warning: Cannot fully validate path without realpath command" >&2
+            fi
+        fi
+    fi
+
+    return 0
+}
+
+#######################################
+# Open file in default browser
+# Arguments:
+#   $1 - Path to file to open
+# Returns:
+#   Exit code 0 on success
+# Note: Tab reuse works automatically since we use same filename
+#######################################
+open_in_browser() {
+    local file_path="$1"
+
+    if [ ! -f "$file_path" ]; then
+        echo "Error: File not found: $file_path" >&2
+        return 1
+    fi
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        open "$file_path"
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        xdg-open "$file_path" 2>/dev/null || true
+    elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+        start "$file_path"
+    else
+        echo "Error: Unsupported operating system: $OSTYPE" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+#######################################
+# Sanitize a string for use in file/directory names
+# Arguments:
+#   $1 - String to sanitize
+#   $2 - Max length (default: 100)
+#   $3 - Fallback if empty (default: "file")
+# Returns:
+#   Sanitized string safe for filenames
+#######################################
+sanitize_name() {
+    local input="$1"
+    local max_length="${2:-100}"
+    local fallback="${3:-file}"
+
+    local safe
+    safe=$(echo "$input" | sed 's/[^a-zA-Z0-9_-]/-/g' | cut -c1-"$max_length")
+    [ -z "$safe" ] && safe="$fallback"
+
+    echo "$safe"
+}
+
+#######################################
+# Generate preview file path
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+# Returns:
+#   Path to preview file (e.g., ".preview-skills/markdown/document.html")
+#######################################
+get_preview_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+
+    local safe_skill
+    local safe_filename
+    safe_skill=$(sanitize_name "$skill_name" 50 "unknown")
+    safe_filename=$(sanitize_name "$filename" 100 "file")
+
+    local output_dir="${PREVIEW_DIR}/${safe_skill}"
+    mkdir -p "$output_dir" 2>/dev/null || {
+        echo "Error: Failed to create preview directory: $output_dir" >&2
+        return 1
+    }
+
+    echo "${output_dir}/${safe_filename}.html"
+}
+
+#######################################
+# Get output file path (custom or default)
+# Arguments:
+#   $1 - Skill name (e.g., "markdown", "mermaid")
+#   $2 - Filename (e.g., "document", "diagram")
+#   $3 - Custom output path (optional, can be file or directory)
+# Returns:
+#   Path to output file
+#######################################
+get_output_file_path() {
+    local skill_name="$1"
+    local filename="$2"
+    local custom_output="${3:-}"
+
+    if [ -z "$custom_output" ]; then
+        get_preview_file_path "$skill_name" "$filename"
+        return
+    fi
+
+    local safe_filename
+    safe_filename=$(sanitize_name "$filename" 100 "file")
+
+    if [ -d "$custom_output" ]; then
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    if [[ "$custom_output" == */ ]]; then
+        mkdir -p "$custom_output" 2>/dev/null || {
+            echo "Error: Cannot create directory: $custom_output" >&2
+            return 1
+        }
+        echo "${custom_output%/}/${safe_filename}.html"
+        return
+    fi
+
+    local parent_dir
+    parent_dir=$(dirname "$custom_output")
+    if [ ! -d "$parent_dir" ]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            echo "Error: Cannot create directory: $parent_dir" >&2
+            return 1
+        }
+    fi
+
+    if [[ "$custom_output" != *.html ]]; then
+        echo "${custom_output}.html"
+    else
+        echo "$custom_output"
+    fi
+}
+
+#######################################
+# Clean up old preview files
+# Arguments:
+#   $1 - Skill name (optional, cleans all if not specified)
+#   $2 - Age in minutes (optional, defaults to 60)
+# Returns:
+#   Number of files removed
+#######################################
+cleanup_old_previews() {
+    local skill_name="${1:-}"
+    local age_minutes="${2:-60}"
+    local search_dir="${PREVIEW_DIR}"
+    local count=0
+
+    if [ -n "$skill_name" ] && [ -d "${PREVIEW_DIR}/${skill_name}" ]; then
+        search_dir="${PREVIEW_DIR}/${skill_name}"
+    fi
+
+    # Find and remove files older than specified age
+    if [ -d "$search_dir" ] && command -v find >/dev/null 2>&1; then
+        while IFS= read -r file; do
+            rm -f "$file"
+            ((count++))
+        done < <(find "$search_dir" -name "*.html" -type f -mmin "+${age_minutes}" 2>/dev/null)
+    fi
+
+    echo "$count"
+}
+
+#######################################
+# Get list of active preview files
+# Arguments:
+#   $1 - Skill name (optional, lists all if not specified)
+# Returns:
+#   List of preview file paths
+#######################################
+list_preview_files() {
+    local skill_name="${1:-}"
+    local search_dir="${PREVIEW_DIR}"
+
+    if [ -n "$skill_name" ] && [ -d "${PREVIEW_DIR}/${skill_name}" ]; then
+        search_dir="${PREVIEW_DIR}/${skill_name}"
+    fi
+
+    # List matching files
+    find "$search_dir" -name "*.html" -type f 2>/dev/null | sort || true
+}
+
+#######################################
+# Check if browser command is available
+# Returns:
+#   Exit code 0 if browser can be opened, 1 otherwise
+#######################################
+check_browser_available() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        command -v open >/dev/null 2>&1
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        command -v xdg-open >/dev/null 2>&1
+    elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+        command -v start >/dev/null 2>&1
+    else
+        return 1
+    fi
+}
+
+#######################################
+# Future: Start live server for preview
+# Arguments:
+#   $1 - Port number (default: 8765)
+#   $2 - Source file to watch
+# Returns:
+#   Server PID
+# Note: Not yet implemented, placeholder for future enhancement
+#######################################
+start_live_server() {
+    local port="${1:-8765}"
+    local source_file="$2"
+
+    echo "Error: Live server not yet implemented" >&2
+    return 1
+}
+
+#######################################
+# Future: Watch file for changes
+# Arguments:
+#   $1 - File to watch
+#   $2 - Callback command to execute on change
+# Returns:
+#   Watcher PID
+# Note: Not yet implemented, placeholder for future enhancement
+#######################################
+watch_file() {
+    local file="$1"
+    local callback="$2"
+
+    echo "Error: File watching not yet implemented" >&2
+    return 1
+}

--- a/skills/preview-svg/lib/content-utils.sh
+++ b/skills/preview-svg/lib/content-utils.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+#===============================================================================
+# AUTO-GENERATED - DO NOT EDIT
+#===============================================================================
+# Source: src/core/lib/content-utils.sh
+# To edit: Modify source file, then run: src/scripts/sync-skills.sh
+#===============================================================================
+
+
+# Content Utilities Library
+# Functions for encoding, escaping, and processing content
+
+# Constants
+readonly MAX_CONTENT_SIZE=$((10 * 1024 * 1024))  # 10MB limit
+readonly MAX_FILE_SIZE=$((50 * 1024 * 1024))     # 50MB file size limit
+readonly MAX_DIFF_FILE_SIZE=$((1 * 1024 * 1024)) # 1MB limit for individual files in diff
+
+#######################################
+# Encode content as UTF-8 safe base64
+# Reads from stdin, writes to stdout
+# Arguments:
+#   None
+# Returns:
+#   Base64 encoded content
+#######################################
+base64_encode_utf8() {
+    base64 | tr -d '\n'
+}
+
+#######################################
+# Decode UTF-8 safe base64 content
+# Arguments:
+#   $1 - Base64 encoded string
+# Returns:
+#   Decoded content
+#######################################
+base64_decode_utf8() {
+    local encoded="$1"
+    echo "$encoded" | base64 -d
+}
+
+#######################################
+# Escape content for use in JavaScript string literals
+# Reads from stdin, writes to stdout
+# Arguments:
+#   None
+# Returns:
+#   Escaped content safe for JS strings
+#######################################
+escape_for_js() {
+    # Escape content for JavaScript strings using sed
+    sed -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g' \
+        -e "s/'/\\\\'/g" \
+        -e ':a' -e 'N' -e '$!ba' \
+        -e 's/\n/\\n/g'
+}
+
+#######################################
+# Escape content for use in HTML
+# Arguments:
+#   $1 - Content to escape
+# Returns:
+#   HTML-safe content
+#######################################
+escape_for_html() {
+    local content="$1"
+    echo "$content" | sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g' \
+        -e "s/'/\&#39;/g"
+}
+
+#######################################
+# Escape string for safe use in HTML attributes/titles
+# More aggressive escaping for untrusted filenames
+# Arguments:
+#   $1 - String to escape
+# Returns:
+#   Safe string for HTML context
+#######################################
+escape_filename_for_html() {
+    local input="$1"
+    # Remove or escape potentially dangerous characters
+    # Allow only alphanumeric, spaces, dots, dashes, underscores
+    echo "$input" | sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g' \
+        -e "s/'/\&#39;/g" \
+        -e 's/`/\&#96;/g' \
+        -e 's/\$/\&#36;/g'
+}
+
+#######################################
+# Read stdin with size limit
+# Arguments:
+#   $1 - Maximum size in bytes (optional, defaults to MAX_CONTENT_SIZE)
+# Returns:
+#   Content from stdin
+#   Exit code 1 if content exceeds limit
+#######################################
+read_with_limit() {
+    local limit="${1:-$MAX_CONTENT_SIZE}"
+    local content
+    local size
+
+    # Read all content
+    content=$(cat)
+    size=${#content}
+
+    if [ "$size" -gt "$limit" ]; then
+        echo "Error: Content size ($size bytes) exceeds limit ($limit bytes)" >&2
+        return 1
+    fi
+
+    echo "$content"
+}
+
+#######################################
+# Validate that content is valid UTF-8
+# Arguments:
+#   $1 - Content to validate
+# Returns:
+#   Exit code 0 if valid, 1 if invalid
+#######################################
+validate_utf8() {
+    local content="$1"
+
+    # Use iconv to validate UTF-8
+    if ! echo "$content" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+        echo "Error: Content is not valid UTF-8" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+#######################################
+# Get MIME type for file extension
+# Arguments:
+#   $1 - File extension (e.g., "md", "json", "mmd")
+# Returns:
+#   MIME type string
+#######################################
+get_mime_type() {
+    local extension="$1"
+
+    case "$extension" in
+        md|markdown)
+            echo "text/markdown"
+            ;;
+        json)
+            echo "application/json"
+            ;;
+        mmd|mermaid)
+            echo "text/x-mermaid"
+            ;;
+        html|htm)
+            echo "text/html"
+            ;;
+        txt)
+            echo "text/plain"
+            ;;
+        csv)
+            echo "text/csv"
+            ;;
+        *)
+            echo "application/octet-stream"
+            ;;
+    esac
+}
+
+#######################################
+# Validate file size before processing
+# Arguments:
+#   $1 - File path
+#   $2 - Maximum size in bytes (optional, defaults to MAX_FILE_SIZE)
+# Returns:
+#   Exit code 0 if valid, 1 if exceeds limit
+#######################################
+validate_file_size() {
+    local file_path="$1"
+    local max_size="${2:-$MAX_FILE_SIZE}"
+
+    if [ ! -f "$file_path" ]; then
+        echo "Error: File not found: $file_path" >&2
+        return 1
+    fi
+
+    # Get file size
+    local file_size
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        file_size=$(stat -f%z "$file_path" 2>/dev/null) || file_size=0
+    else
+        file_size=$(stat -c%s "$file_path" 2>/dev/null) || file_size=0
+    fi
+
+    if [ "$file_size" -gt "$max_size" ]; then
+        echo "Error: File size ($file_size bytes) exceeds limit ($max_size bytes)" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+#######################################
+# Check if file is binary
+# Arguments:
+#   $1 - File path
+# Returns:
+#   Exit code 0 if binary, 1 if text
+#######################################
+is_binary_file() {
+    local file_path="$1"
+
+    if [ ! -f "$file_path" ]; then
+        return 1
+    fi
+
+    # Use file command if available
+    if command -v file >/dev/null 2>&1; then
+        if file "$file_path" | grep -q "text"; then
+            return 1  # Text file
+        else
+            return 0  # Binary file
+        fi
+    fi
+
+    # Fallback: check for null bytes in first 8KB
+    if head -c 8192 "$file_path" | grep -q $'\0'; then
+        return 0  # Binary
+    fi
+
+    return 1  # Text
+}
+
+#######################################
+# Read file safely with size and content validation
+# Arguments:
+#   $1 - File path
+#   $2 - Maximum size in bytes (optional)
+# Returns:
+#   File content
+#   Exit code 1 if file is invalid or too large
+#######################################
+read_file_safely() {
+    local file_path="$1"
+    local max_size="${2:-$MAX_FILE_SIZE}"
+
+    # Validate file exists and size
+    validate_file_size "$file_path" "$max_size" || return 1
+
+    # Check if binary
+    if is_binary_file "$file_path"; then
+        echo "Error: File appears to be binary: $file_path" >&2
+        return 1
+    fi
+
+    # Read file content
+    cat "$file_path"
+}

--- a/skills/preview-svg/lib/html-generator.sh
+++ b/skills/preview-svg/lib/html-generator.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+
+#===============================================================================
+# AUTO-GENERATED - DO NOT EDIT
+#===============================================================================
+# Source: src/core/lib/html-generator.sh
+# To edit: Modify source file, then run: src/scripts/sync-skills.sh
+#===============================================================================
+
+
+# HTML Generator Library
+# Core HTML generation functions
+
+# Get the library root directory
+if [ -z "$LIB_ROOT" ]; then
+    LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+# Allowed CDN domains (whitelist)
+readonly ALLOWED_CDN_DOMAINS=(
+    "cdn.jsdelivr.net"
+    "cdnjs.cloudflare.com"
+    "unpkg.com"
+    "fonts.googleapis.com"
+    "fonts.gstatic.com"
+)
+
+# Security setting: require SRI hashes for all CDN resources
+# Set to "1" to enforce SRI (recommended for production)
+# Set to "0" to allow CDN resources without SRI (for development only)
+REQUIRE_SRI_HASHES="${REQUIRE_SRI_HASHES:-1}"
+
+#######################################
+# Validate CDN URL against whitelist
+# Arguments:
+#   $1 - URL to validate
+# Returns:
+#   Exit code 0 if valid, 1 if invalid
+#######################################
+validate_cdn_url() {
+    local url="$1"
+
+    # Check if URL starts with https://
+    if [[ ! "$url" =~ ^https:// ]]; then
+        echo "Warning: CDN URL must use HTTPS: $url" >&2
+        return 1
+    fi
+
+    # Extract domain from URL
+    local domain
+    domain=$(echo "$url" | sed -E 's|^https://([^/]+).*|\1|')
+
+    # Check if domain is in whitelist
+    for allowed_domain in "${ALLOWED_CDN_DOMAINS[@]}"; do
+        if [[ "$domain" == "$allowed_domain" ]]; then
+            return 0
+        fi
+    done
+
+    echo "Warning: CDN domain not in whitelist: $domain" >&2
+    return 1
+}
+
+#######################################
+# Load CSS content from file or return import for CDN URL
+# Arguments:
+#   $1 - Path to CSS file (absolute, relative to LIB_ROOT, CDN URL, or URL::INTEGRITY)
+# Returns:
+#   CSS content or link tag for CDN with SRI
+#######################################
+load_css() {
+    local css_entry="$1"
+
+    # Check if it's a CDN URL with optional SRI hash
+    if [[ "$css_entry" =~ ^https?:// ]]; then
+        # Parse URL and optional integrity hash
+        local css_url="${css_entry%%::*}"
+        local integrity="${css_entry#*::}"
+
+        # If no :: delimiter, integrity will equal css_url
+        if [ "$integrity" == "$css_url" ]; then
+            integrity=""
+        fi
+
+        # Validate and return appropriate format
+        if [ -n "$integrity" ]; then
+            # Return marker for later processing in generate_html
+            echo "CDN_LINK::${css_url}::${integrity}"
+        elif [ "$REQUIRE_SRI_HASHES" = "1" ]; then
+            echo "Error: CDN stylesheet without SRI hash (REQUIRE_SRI_HASHES=1): $css_url" >&2
+            echo "Add SRI hash using format: URL::sha384-HASH" >&2
+            return 1
+        else
+            echo "Warning: CDN stylesheet without SRI hash: $css_url" >&2
+            echo "@import url('$css_url');"
+        fi
+        return 0
+    fi
+
+    # Local file path
+    local css_path="$css_entry"
+
+    # Check if path is absolute
+    if [[ "$css_path" != /* ]]; then
+        css_path="$LIB_ROOT/$css_path"
+    fi
+
+    if [ -f "$css_path" ]; then
+        cat "$css_path"
+    else
+        echo "/* Warning: CSS file not found: $css_path */" >&2
+    fi
+}
+
+#######################################
+# Load JavaScript content from file
+# Arguments:
+#   $1 - Path to JS file (absolute or relative to LIB_ROOT)
+# Returns:
+#   JavaScript content
+#######################################
+load_js() {
+    local js_path="$1"
+
+    # Check if path is absolute
+    if [[ "$js_path" != /* ]]; then
+        js_path="$LIB_ROOT/$js_path"
+    fi
+
+    if [ -f "$js_path" ]; then
+        cat "$js_path"
+    else
+        echo "// Warning: JS file not found: $js_path" >&2
+    fi
+}
+
+#######################################
+# Merge multiple CSS files
+# Arguments:
+#   $@ - Paths to CSS files
+# Returns:
+#   Combined output with format:
+#     CDN_LINKS_START
+#     <link tags>
+#     CDN_LINKS_END
+#     <css content>
+#######################################
+merge_styles() {
+    local imports=""
+    local styles=""
+    local cdn_links=""
+
+    # Process all CSS files
+    for css_file in "$@"; do
+        if [ -n "$css_file" ]; then
+            local css_content
+            css_content=$(load_css "$css_file")
+
+            # Check for CDN_LINK marker
+            if [[ "$css_content" =~ ^CDN_LINK:: ]]; then
+                # Extract URL and integrity
+                local url="${css_content#CDN_LINK::}"
+                local cdn_url="${url%%::*}"
+                local integrity="${url#*::}"
+
+                # Generate link tag
+                cdn_links+="    <link rel=\"stylesheet\" href=\"${cdn_url}\" integrity=\"${integrity}\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\">"
+                cdn_links+=$'\n'
+            # Separate @import rules from regular styles
+            elif [[ "$css_content" =~ ^@import ]]; then
+                imports+="$css_content"
+                imports+=$'\n'
+            else
+                styles+="$css_content"
+                styles+=$'\n'
+            fi
+        fi
+    done
+
+    # Return CDN links and styles in parseable format
+    echo "CDN_LINKS_START"
+    echo -n "$cdn_links"
+    echo "CDN_LINKS_END"
+    echo -n "${imports}${styles}"
+}
+
+#######################################
+# Generate CDN script tags
+# Arguments:
+#   $@ - CDN URLs or URL::INTEGRITY pairs
+# Returns:
+#   HTML script tags with SRI hashes
+# Format:
+#   - Simple URL: https://cdn.example.com/lib.js
+#   - With SRI: https://cdn.example.com/lib.js::sha384-HASH
+#######################################
+generate_cdn_scripts() {
+    local scripts=""
+
+    for cdn_entry in "$@"; do
+        if [ -n "$cdn_entry" ]; then
+            # Parse URL and optional integrity hash
+            local cdn_url="${cdn_entry%%::*}"
+            local integrity="${cdn_entry#*::}"
+
+            # If no :: delimiter, integrity will equal cdn_url
+            if [ "$integrity" == "$cdn_url" ]; then
+                integrity=""
+            fi
+
+            # Validate CDN URL before adding
+            if validate_cdn_url "$cdn_url"; then
+                if [ -n "$integrity" ]; then
+                    scripts+="    <script src=\"${cdn_url}\" integrity=\"${integrity}\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>"
+                    scripts+=$'\n'
+                elif [ "$REQUIRE_SRI_HASHES" = "1" ]; then
+                    echo "Error: CDN script without SRI hash (REQUIRE_SRI_HASHES=1): $cdn_url" >&2
+                    echo "Add SRI hash using format: URL::sha384-HASH" >&2
+                    return 1
+                else
+                    echo "Warning: CDN script without SRI hash: $cdn_url" >&2
+                    scripts+="    <script src=\"${cdn_url}\" crossorigin=\"anonymous\" referrerpolicy=\"no-referrer\"></script>"
+                    scripts+=$'\n'
+                fi
+            else
+                echo "Error: Invalid CDN URL rejected: $cdn_url" >&2
+                return 1
+            fi
+        fi
+    done
+
+    echo "$scripts"
+}
+
+#######################################
+# Generate complete HTML document
+# Uses environment variables:
+#   HTML_TITLE - Page title
+#   HTML_CDN_SCRIPTS - Array of CDN script URLs
+#   HTML_STYLE_FILES - Array of CSS file paths
+#   HTML_CUSTOM_STYLES - Inline CSS string
+#   HTML_LAYOUT - Layout type (document, centered, full)
+#   HTML_BACKGROUND - Background color
+#   HTML_CONTENT - Content HTML
+#   HTML_COMMON_JS - Common JavaScript
+#   HTML_CUSTOM_JS - Custom JavaScript (render script)
+#   HTML_OUTPUT - Output file path
+# Returns:
+#   Generates HTML file
+#######################################
+generate_html() {
+    local title="${HTML_TITLE:-Preview}"
+    local layout="${HTML_LAYOUT:-document}"
+    local background="${HTML_BACKGROUND:-#f5f5f5}"
+    local output="${HTML_OUTPUT:-.preview-skills/preview.html}"
+
+    # Generate CDN script tags
+    local cdn_scripts=""
+    if [ ${#HTML_CDN_SCRIPTS[@]} -gt 0 ]; then
+        cdn_scripts=$(generate_cdn_scripts "${HTML_CDN_SCRIPTS[@]}")
+    fi
+
+    # Merge CSS files and extract CDN links
+    local combined_styles=""
+    local cdn_css_links=""
+
+    if [ ${#HTML_STYLE_FILES[@]} -gt 0 ]; then
+        local merge_result
+        merge_result=$(merge_styles "${HTML_STYLE_FILES[@]}")
+
+        # Parse output to extract CDN links and styles
+        if [[ "$merge_result" =~ CDN_LINKS_START ]]; then
+            # Extract CDN links section
+            cdn_css_links=$(echo "$merge_result" | sed -n '/CDN_LINKS_START/,/CDN_LINKS_END/p' | sed '1d;$d')
+            # Extract styles section (everything after CDN_LINKS_END)
+            combined_styles=$(echo "$merge_result" | sed -n '/CDN_LINKS_END/,$p' | tail -n +2)
+        else
+            # No CDN links, just styles
+            combined_styles="$merge_result"
+        fi
+    fi
+
+    # Add custom inline styles
+    if [ -n "${HTML_CUSTOM_STYLES:-}" ]; then
+        combined_styles+=$'\n'
+        combined_styles+="$HTML_CUSTOM_STYLES"
+    fi
+
+    # Load common JavaScript
+    local common_js=""
+    if [ -n "${HTML_COMMON_JS:-}" ]; then
+        common_js="$HTML_COMMON_JS"
+    else
+        common_js=$(load_js "templates/scripts/utils.js")
+    fi
+
+    # Custom JavaScript
+    local custom_js="${HTML_CUSTOM_JS:-}"
+
+    # Layout-specific body styles
+    local body_styles="background: ${background}; margin: 0; padding: 0;"
+
+    # Content wrapper
+    local content="${HTML_CONTENT:-<div id=\"content\"></div>}"
+
+    # Determine if base href is set (for relative path resolution)
+    local base_tag=""
+    local file_scheme=""
+    if [ -n "${HTML_BASE_HREF:-}" ]; then
+        base_tag="    <base href=\"${HTML_BASE_HREF}\">"
+        file_scheme=" file:"
+    fi
+
+    # Generate CSP header
+    local csp_header="default-src 'self'; "
+    csp_header+="script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com; "
+    csp_header+="style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://fonts.googleapis.com; "
+    csp_header+="font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; "
+    csp_header+="img-src 'self' data: https:${file_scheme}; "
+    csp_header+="connect-src 'self' https://cdn.jsdelivr.net https://unpkg.com; "
+    csp_header+="object-src 'none'; "
+    csp_header+="base-uri 'self'${file_scheme}; "
+    csp_header+="form-action 'self'; "
+    csp_header+="frame-ancestors 'none';"
+
+    # Set secure permissions before writing (owner read/write, others read-only)
+    # 644 allows browser to read the file while preventing modification by others
+    touch "$output"
+    chmod 644 "$output" 2>/dev/null || true
+
+    # Write HTML header
+    cat > "$output" <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+${base_tag}
+    <meta http-equiv="Content-Security-Policy" content="${csp_header}">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="X-Frame-Options" content="DENY">
+    <title>${title}</title>
+${cdn_scripts}
+${cdn_css_links}
+    <style>
+${combined_styles}
+        body {
+            ${body_styles}
+        }
+    </style>
+</head>
+<body>
+    <div id="container" class="layout-${layout}">
+${content}
+    </div>
+    <script>
+EOF
+
+    # Write JavaScript content separately (can be very large)
+    printf '%s\n\n' "$common_js" >> "$output"
+    printf '%s\n' "$custom_js" >> "$output"
+
+    # Write HTML footer
+    cat >> "$output" <<'EOF'
+    </script>
+</body>
+</html>
+EOF
+
+    return 0
+}
+
+#######################################
+# Generate HTML with simple interface
+# Arguments:
+#   All arguments are key=value pairs
+#   Supported keys:
+#     title - Page title
+#     cdn - CDN script URL (can be specified multiple times)
+#     style - CSS file path (can be specified multiple times)
+#     layout - Layout type (document, centered, full)
+#     background - Background color
+#     content - HTML content
+#     js - Custom JavaScript
+#     output - Output file path
+# Example:
+#   generate_html_simple \
+#     title="My Page" \
+#     cdn="https://cdn.example.com/lib.js" \
+#     style="templates/styles/common.css" \
+#     layout="document" \
+#     output="/tmp/page.html"
+#######################################
+generate_html_simple() {
+    # Reset environment variables
+    unset HTML_TITLE HTML_CDN_SCRIPTS HTML_STYLE_FILES HTML_CUSTOM_STYLES
+    unset HTML_LAYOUT HTML_BACKGROUND HTML_CONTENT HTML_COMMON_JS HTML_CUSTOM_JS HTML_OUTPUT
+
+    # Arrays for multiple values
+    HTML_CDN_SCRIPTS=()
+    HTML_STYLE_FILES=()
+
+    # Parse arguments
+    for arg in "$@"; do
+        local key="${arg%%=*}"
+        local value="${arg#*=}"
+
+        case "$key" in
+            title)
+                HTML_TITLE="$value"
+                ;;
+            cdn)
+                HTML_CDN_SCRIPTS+=("$value")
+                ;;
+            style)
+                HTML_STYLE_FILES+=("$value")
+                ;;
+            layout)
+                HTML_LAYOUT="$value"
+                ;;
+            background)
+                HTML_BACKGROUND="$value"
+                ;;
+            content)
+                HTML_CONTENT="$value"
+                ;;
+            js)
+                HTML_CUSTOM_JS="$value"
+                ;;
+            output)
+                HTML_OUTPUT="$value"
+                ;;
+        esac
+    done
+
+    # Export for generate_html
+    export HTML_TITLE HTML_LAYOUT HTML_BACKGROUND HTML_OUTPUT
+    export HTML_CDN_SCRIPTS HTML_STYLE_FILES HTML_CUSTOM_STYLES
+    export HTML_CONTENT HTML_COMMON_JS HTML_CUSTOM_JS
+
+    # Generate HTML
+    generate_html
+}

--- a/skills/preview-svg/run.sh
+++ b/skills/preview-svg/run.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+
+#===============================================================================
+# AUTO-GENERATED - DO NOT EDIT
+#===============================================================================
+# Source: src/preview-skills/run.sh
+# To edit: Modify source file, then run: src/scripts/sync-skills.sh
+#===============================================================================
+
+
+# Universal Preview Tool
+# Usage: ./run.sh <file> [-o output] [--no-browser]
+#    OR: cat content | ./run.sh [name] [-o output] [--no-browser]
+#
+# Options:
+#   -o, --output    Output file path or directory (default: .preview-skills/)
+#   --no-browser    Skip opening browser, just output file path
+
+set -euo pipefail
+
+# Parse options
+OUTPUT_PATH=""
+NO_BROWSER=0
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        --no-browser)
+            NO_BROWSER=1
+            shift
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]:-}"
+
+# Get directories (standalone skill)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$SCRIPT_DIR"
+LIB_ROOT="$SKILL_ROOT"
+
+# Source shared libraries
+source "$LIB_ROOT/lib/content-utils.sh"
+source "$LIB_ROOT/lib/browser-utils.sh"
+source "$LIB_ROOT/lib/html-generator.sh"
+
+# Default functions (can be overridden in config.sh)
+validate_content() {
+    return 0  # No validation by default
+}
+
+preprocess_content() {
+    echo "$1"  # Return content unchanged by default
+}
+
+get_additional_params() {
+    echo ""  # No additional params by default
+}
+
+generate_metadata() {
+    echo "{}"  # Empty metadata by default
+}
+
+# Load tool configuration (may override default functions above)
+source "$SCRIPT_DIR/config.sh"
+
+# Check if first argument is a file
+if [ -f "${1:-}" ]; then
+    SOURCE_FILE="$1"
+
+    # Validate file path for security
+    validate_file_path "$SOURCE_FILE" "$(pwd)" || exit 1
+
+    # Extract filename (remove any of the configured extensions)
+    FILENAME="$(basename "$SOURCE_FILE")"
+    for ext in "${FILE_EXTENSIONS[@]}"; do
+        FILENAME="${FILENAME%"$ext"}"
+    done
+
+    # Get additional parameters (background color, theme, etc.)
+    shift
+    ADDITIONAL_PARAMS=$(get_additional_params "$@")
+
+    # Validate file size
+    validate_file_size "$SOURCE_FILE" "$MAX_CONTENT_SIZE" || exit 1
+
+    CONTENT=$(cat "$SOURCE_FILE")
+else
+    FILENAME="${1:-$DEFAULT_FILENAME}"
+
+    # Get additional parameters
+    shift || true
+    ADDITIONAL_PARAMS=$(get_additional_params "$@")
+
+    # Read stdin with size limit
+    CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
+fi
+
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+    SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
+    # Encode URL-unsafe characters for file:// URI
+    SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"
+    SOURCE_DIR_URL="${SOURCE_DIR_URL// /%20}"
+    SOURCE_DIR_URL="${SOURCE_DIR_URL//#/%23}"
+    SOURCE_DIR_URL="${SOURCE_DIR_URL//\?/%3F}"
+    export HTML_BASE_HREF="file://${SOURCE_DIR_URL}/"
+fi
+
+# Validate content (tool-specific)
+validate_content "$CONTENT" || exit 1
+
+# Preprocess content (tool-specific - may add metadata, detect types, etc.)
+CONTENT=$(preprocess_content "$CONTENT")
+
+# Encode content based on configuration
+if [ "$CONTENT_ENCODING" = "base64" ]; then
+    CONTENT_ENCODED=$(echo "$CONTENT" | base64_encode_utf8)
+else
+    CONTENT_ENCODED="$CONTENT"
+fi
+
+# Load renderer script and substitute variables
+RENDER_SCRIPT=$(cat "$LIB_ROOT/$RENDERER_FILE")
+
+# Perform variable substitutions defined in config
+# Convention:
+#   - Variables ending in _ENCODED, _DATA, _CONTENT, _CODE → content variables
+#   - Other variables → parameter variables (use shell var with same name if exists)
+if [ ${#RENDERER_VARS[@]} -gt 0 ]; then
+    for var in "${RENDERER_VARS[@]}"; do
+        # Check if this is a content variable (ends with _ENCODED, _DATA, _CONTENT, or _CODE)
+        if [[ "$var" =~ _(ENCODED|DATA|CONTENT|CODE)$ ]]; then
+            # Content variable - use CONTENT_ENCODED or CONTENT based on encoding
+            if [ "$CONTENT_ENCODING" = "base64" ]; then
+                RENDER_SCRIPT="${RENDER_SCRIPT//$var/$CONTENT_ENCODED}"
+            else
+                RENDER_SCRIPT="${RENDER_SCRIPT//$var/$CONTENT}"
+            fi
+        else
+            # Parameter variable - check if a shell variable with this name exists
+            if [ -n "${!var:-}" ]; then
+                # Use the value of the shell variable with the same name
+                RENDER_SCRIPT="${RENDER_SCRIPT//$var/${!var}}"
+            else
+                # No shell variable found - leave as-is or use empty string
+                echo "Warning: No value found for renderer variable: $var" >&2
+            fi
+        fi
+    done
+fi
+
+# Generate output file path
+OUTPUT_FILE=$(get_output_file_path "$TOOL_NAME" "$FILENAME" "$OUTPUT_PATH")
+
+# Load common JavaScript libraries
+UTILS_JS=$(cat "$LIB_ROOT/templates/scripts/utils.js")
+COMMON_UI=$(cat "$LIB_ROOT/templates/scripts/common-ui.js")
+COMMON_JS="${UTILS_JS}
+
+${COMMON_UI}"
+
+# Set up HTML generation environment
+# Escape filename to prevent HTML injection via malicious filenames
+SAFE_FILENAME=$(escape_filename_for_html "$FILENAME")
+export HTML_TITLE="${TOOL_TITLE_PREFIX} - ${SAFE_FILENAME}"
+
+# Handle CDN scripts array
+if [ ${#CDN_SCRIPTS[@]} -gt 0 ]; then
+    export HTML_CDN_SCRIPTS=("${CDN_SCRIPTS[@]}")
+else
+    export HTML_CDN_SCRIPTS=()
+fi
+
+export HTML_STYLE_FILES=("${STYLE_FILES[@]}")
+export HTML_LAYOUT="$LAYOUT_TYPE"
+export HTML_BACKGROUND="${BACKGROUND_COLOR}"
+export HTML_COMMON_JS="$COMMON_JS"
+export HTML_CUSTOM_JS="$RENDER_SCRIPT"
+export HTML_OUTPUT="$OUTPUT_FILE"
+
+# Handle user code template for interactive tools (D3, ThreeJS, Leaflet)
+if [ "${NEEDS_USER_CODE_TEMPLATE:-0}" = "1" ]; then
+    # Write user code to separate JavaScript file
+    USER_CODE_FILE="${OUTPUT_FILE%.html}-user.js"
+
+    cat > "$USER_CODE_FILE" <<'USERCODE'
+/* eslint-disable no-unused-vars */
+// User code - executes when dynamically loaded
+USERCODE
+    echo "$CONTENT" >> "$USER_CODE_FILE"
+    chmod 644 "$USER_CODE_FILE"
+
+    # Get filename for script src attribute
+    USER_CODE_FILENAME=$(basename "$USER_CODE_FILE")
+
+    # Generate metadata (calls generate_metadata from config, defaults to empty)
+    METADATA_JSON=$(generate_metadata "$CONTENT")
+
+    # Validate METADATA_JSON is valid JSON and escape for template safety
+    # Prevent envsubst injection by ensuring no unescaped $ characters in values
+    if ! echo "$METADATA_JSON" | grep -qE '^\s*\{.*\}\s*$'; then
+        echo "Warning: Invalid METADATA_JSON format, using empty object" >&2
+        METADATA_JSON="{}"
+    fi
+
+    # Export variables for envsubst template substitution
+    export TOOL_NAME
+    export METADATA_JSON
+    export USER_CODE_SRC="$USER_CODE_FILENAME"
+
+    # Generate HTML content using envsubst
+    HTML_CONTENT=$(envsubst < "$LIB_ROOT/templates/user-code-template.html")
+    export HTML_CONTENT
+else
+    export HTML_CONTENT='        <div id="content"></div>'
+fi
+
+# Generate HTML
+generate_html
+
+echo "Preview created: $OUTPUT_FILE"
+
+# Open in browser (unless --no-browser flag is set)
+if [ "$NO_BROWSER" != "1" ]; then
+    open_in_browser "$OUTPUT_FILE"
+fi

--- a/skills/preview-svg/templates/scripts/common-ui.js
+++ b/skills/preview-svg/templates/scripts/common-ui.js
@@ -1,0 +1,119 @@
+//==============================================================================
+// AUTO-GENERATED - DO NOT EDIT
+//==============================================================================
+// Source: src/core/templates/scripts/common-ui.js
+// To edit: Modify source file, then run: src/scripts/sync-skills.sh
+//==============================================================================
+
+/* eslint-disable no-unused-vars */
+// Functions in this file are used by other scripts and HTML onclick handlers
+
+const GITHUB_REPO = 'https://github.com/veelenga/preview-skills';
+
+function initTheme() {
+  const savedTheme = localStorage.getItem('theme') || 'light';
+  document.documentElement.setAttribute('data-theme', savedTheme);
+}
+
+function toggleTheme() {
+  const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+  const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-theme', newTheme);
+  localStorage.setItem('theme', newTheme);
+}
+
+function createHeader(title, stats, toolbarItems = []) {
+  const themeToggle = `
+        <div class="theme-toggle-wrapper">
+            <span class="theme-label">Theme</span>
+            <div class="theme-toggle" onclick="toggleTheme()" title="Toggle theme"></div>
+        </div>
+    `;
+
+  const statsHtml = stats ? `<span class="preview-header-stats">${stats}</span>` : '';
+  const toolbarHtml =
+    toolbarItems.length > 0 ? `<div class="preview-toolbar">${toolbarItems.join('')}</div>` : '';
+
+  return `
+        <div class="preview-header">
+            <div class="preview-header-info">
+                <strong class="preview-header-title">${title}</strong>
+                ${statsHtml}
+            </div>
+            ${toolbarHtml}
+            ${themeToggle}
+        </div>
+    `;
+}
+
+initTheme();
+
+function createSearchBox(onInput, onClear) {
+  return `
+        <div class="search-box">
+            <span class="search-icon">🔍</span>
+            <input type="text" class="search-input" placeholder="Search... (Ctrl+F)" oninput="${onInput}">
+            <button class="search-clear" onclick="${onClear}">×</button>
+        </div>
+    `;
+}
+
+function createButton(label, onclick, icon = '') {
+  const iconHtml = icon ? icon + ' ' : '';
+  return `<button class="action-btn" onclick="${onclick}">${iconHtml}${label}</button>`;
+}
+
+function createFooter() {
+  const year = new Date().getFullYear();
+  return `
+        <div class="preview-footer">
+            <div class="footer-links">
+                <a href="${GITHUB_REPO}" target="_blank" class="footer-link">
+                    <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+                    </svg>
+                    Source
+                </a>
+                <a href="${GITHUB_REPO}/blob/main/LICENSE" target="_blank" class="footer-link">
+                    <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
+                    </svg>
+                    MIT License
+                </a>
+            </div>
+            <div class="footer-copyright">
+                ${year} Preview Skill. Built with <span style="color: #ef4444;">❤</span> by <a href="https://github.com/veelenga" target="_blank" class="footer-author">veelenga</a>
+            </div>
+        </div>
+    `;
+}
+
+function showStatus(message) {
+  const existing = document.querySelector('.status-message');
+  if (existing) existing.remove();
+
+  const statusDiv = document.createElement('div');
+  statusDiv.className = 'status-message';
+  statusDiv.textContent = message;
+  document.body.appendChild(statusDiv);
+
+  setTimeout(() => {
+    statusDiv.style.animation = 'slideOut 0.3s ease-in';
+    setTimeout(() => statusDiv.remove(), 300);
+  }, 2000);
+}
+
+function initSearchShortcut(inputSelector) {
+  document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+      e.preventDefault();
+      document.querySelector(inputSelector).focus();
+    }
+  });
+}
+
+function copyToClipboard(text, successMessage = 'Copied to clipboard!') {
+  navigator.clipboard.writeText(text).then(() => {
+    showStatus(successMessage);
+  });
+}

--- a/skills/preview-svg/templates/scripts/svg-renderer.js
+++ b/skills/preview-svg/templates/scripts/svg-renderer.js
@@ -1,0 +1,370 @@
+/* eslint-disable no-unused-vars, no-undef */
+
+// SVG Animation Renderer
+// Injects user SVG into the page, wires up animation controls (play/pause/
+// restart/scrub), zoom & pan via viewBox manipulation, and SVG export.
+
+const IDS = {
+  scrub: 'svg-scrub',
+  playBtn: 'svg-play-btn',
+  codePanel: 'svg-code-panel',
+};
+const ZOOM_MIN = 0.2;
+const ZOOM_MAX = 20;
+const ZOOM_STEP = 1.1;
+const SCRUB_RESOLUTION = 1000;
+const SCRUB_POLL_MS = 100;
+const DEFAULT_DURATION_S = 5;
+const DEFAULT_VIEWBOX = 400;
+const EXPORT_FILENAME = 'animation.svg';
+
+const ICON_PAUSE = '<span class="svg-icon-pause">‖</span>';
+const ICON_PLAY = '<span class="svg-icon-play">▶</span>';
+
+const __svgPreviewContainer = document.getElementById('content');
+const __svgRawContent = base64DecodeUnicode('SVG_CONTENT_ENCODED');
+
+function detectFeatures(src) {
+  const features = [];
+  if (/<animate\b|<animateTransform\b|<animateMotion\b|<set\b/.test(src)) {
+    features.push('SMIL');
+  }
+  if (/@keyframes|animation\s*:|animation-name|transition\s*:/.test(src)) {
+    features.push('CSS anim');
+  }
+  if (/<script\b/i.test(src)) {
+    features.push('JS');
+  }
+  return features.length ? features.join(', ') : 'static';
+}
+
+function estimateDuration(src) {
+  // Authors stagger restarts with begin="A;B;…". The gap B-A is the loop
+  // period of that animation; when several animations share the same gap,
+  // that gap IS the visible loop period. Otherwise fall back to maxBegin+maxDur.
+  const re = /\b(begin|dur)\s*=\s*"([^"]+)"/g;
+  let m;
+  const durs = [];
+  const beginListGaps = [];
+  let maxFlatBegin = 0;
+  while ((m = re.exec(src)) !== null) {
+    if (m[1] === 'dur') {
+      const t = parseTime(m[2]);
+      if (t != null) durs.push(t);
+      continue;
+    }
+    const beginValues = m[2]
+      .split(';')
+      .map((v) => parseTime(v.trim()))
+      .filter((t) => t != null);
+    if (beginValues.length === 0) continue;
+    maxFlatBegin = Math.max(maxFlatBegin, ...beginValues);
+    for (let i = 1; i < beginValues.length; i++) {
+      const gap = beginValues[i] - beginValues[i - 1];
+      if (gap > 0) beginListGaps.push(gap);
+    }
+  }
+
+  const maxDur = durs.length ? Math.max(...durs) : 0;
+
+  if (beginListGaps.length > 0) {
+    const sorted = [...beginListGaps].sort((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)];
+    if (median > 0) return median;
+  }
+
+  const total = maxFlatBegin + maxDur;
+  return total > 0 ? total : DEFAULT_DURATION_S;
+}
+
+function parseTime(value) {
+  const v = String(value).trim();
+  if (/^[\d.]+ms$/.test(v)) return parseFloat(v) / 1000;
+  if (/^[\d.]+s$/.test(v)) return parseFloat(v);
+  if (/^[\d.]+$/.test(v)) return parseFloat(v);
+  return null;
+}
+
+function buildSvgElement(raw) {
+  // Strip XML declaration; the browser DOM doesn't need it.
+  let content = raw.replace(/<\?xml[^?]*\?>\s*/, '');
+
+  // If the user gave us a fragment (no <svg> root), wrap it in a default SVG.
+  if (!/<svg[\s>]/i.test(content)) {
+    content = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${DEFAULT_VIEWBOX} ${DEFAULT_VIEWBOX}">${content}</svg>`;
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(content, 'image/svg+xml');
+  const parseError = doc.querySelector('parsererror');
+  if (parseError) {
+    throw new Error('SVG parse error: ' + parseError.textContent);
+  }
+  const svgEl = doc.documentElement;
+  if (svgEl.namespaceURI !== 'http://www.w3.org/2000/svg') {
+    throw new Error('Root element is not an SVG.');
+  }
+  if (!svgEl.getAttribute('xmlns')) {
+    svgEl.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  }
+  if (!svgEl.getAttribute('viewBox')) {
+    const w = svgEl.getAttribute('width') || DEFAULT_VIEWBOX;
+    const h = svgEl.getAttribute('height') || DEFAULT_VIEWBOX;
+    svgEl.setAttribute('viewBox', `0 0 ${parseFloat(w)} ${parseFloat(h)}`);
+  }
+  svgEl.removeAttribute('width');
+  svgEl.removeAttribute('height');
+  svgEl.classList.add('preview-svg');
+  return svgEl;
+}
+
+function buildShell(duration) {
+  // Header keeps view/meta controls only — playback lives next to the scrubber.
+  const toolbarItems = [
+    createButton('Reset Zoom', 'svgResetZoom()', '⊙'),
+    createButton('Code', 'svgToggleCode()', '⟨⟩'),
+    createButton('Export', 'svgExport()', '⬇'),
+  ];
+
+  return (
+    createHeader('SVG Animation', stats, toolbarItems) +
+    '<div class="preview-body">' +
+    '  <div class="svg-stage"></div>' +
+    '  <div class="svg-timeline-wrap">' +
+    `    <button class="svg-play-btn" id="${IDS.playBtn}" title="Play / Pause" aria-label="Play / Pause" onclick="svgTogglePlay()">${ICON_PAUSE}</button>` +
+    '    <button class="svg-play-btn" id="svg-restart-btn" title="Restart" aria-label="Restart" onclick="svgRestart()">' +
+    '      <span>⟲</span>' +
+    '    </button>' +
+    '    <span class="svg-time svg-time-start">0.0s</span>' +
+    '    <div class="svg-scrub-wrap">' +
+    `      <input type="range" min="0" max="${SCRUB_RESOLUTION}" value="0" step="1" class="svg-scrub" id="${IDS.scrub}">` +
+    '    </div>' +
+    `    <span class="svg-time svg-time-end">${duration.toFixed(1)}s</span>` +
+    '  </div>' +
+    `  <pre class="svg-code-panel" id="${IDS.codePanel}" hidden></pre>` +
+    '</div>' +
+    createFooter()
+  );
+}
+
+const features = detectFeatures(__svgRawContent);
+const duration = estimateDuration(__svgRawContent);
+const lines = __svgRawContent.split('\n').length;
+const chars = __svgRawContent.length;
+const stats = `${lines} lines • ${chars} chars • ${features} • ~${duration.toFixed(1)}s`;
+
+__svgPreviewContainer.innerHTML = buildShell(duration);
+
+// Cache element references after the shell is in the DOM.
+const __scrubEl = document.getElementById(IDS.scrub);
+const __playBtnEl = document.getElementById(IDS.playBtn);
+const __codePanelEl = document.getElementById(IDS.codePanel);
+
+let __svgEl;
+let __zoomCtrl;
+let __cssAnimNodes = []; // cached once after SVG injection; see collectCssAnimNodes
+try {
+  __svgEl = buildSvgElement(__svgRawContent);
+  document.querySelector('.svg-stage').appendChild(__svgEl);
+} catch (err) {
+  showError(err.message);
+}
+
+if (__svgEl) {
+  __zoomCtrl = setupZoomAndPan(__svgEl);
+  __cssAnimNodes = collectCssAnimNodes(__svgEl);
+  wireScrub(__svgEl, duration);
+  if (__codePanelEl) __codePanelEl.textContent = __svgRawContent;
+}
+
+// ---- Playback controls -----------------------------------------------------
+
+let __svgPaused = false;
+
+function svgTogglePlay() {
+  if (!__svgEl) return;
+  if (__svgPaused) {
+    if (typeof __svgEl.unpauseAnimations === 'function') __svgEl.unpauseAnimations();
+    setCssPlayState('running');
+    __svgPaused = false;
+    if (__playBtnEl) __playBtnEl.innerHTML = ICON_PAUSE;
+  } else {
+    if (typeof __svgEl.pauseAnimations === 'function') __svgEl.pauseAnimations();
+    setCssPlayState('paused');
+    __svgPaused = true;
+    if (__playBtnEl) __playBtnEl.innerHTML = ICON_PLAY;
+  }
+}
+
+function svgRestart() {
+  if (!__svgEl) return;
+  if (typeof __svgEl.setCurrentTime === 'function') {
+    __svgEl.setCurrentTime(0);
+  }
+  restartCssAnimations();
+  if (__scrubEl) __scrubEl.value = 0;
+}
+
+function svgToggleCode() {
+  if (__codePanelEl) __codePanelEl.hidden = !__codePanelEl.hidden;
+}
+
+function svgResetZoom() {
+  if (__zoomCtrl) {
+    __zoomCtrl.reset();
+    showStatus('Zoom reset');
+  }
+}
+
+function svgExport() {
+  if (!__svgEl) return;
+  const serializer = new XMLSerializer();
+  let data = serializer.serializeToString(__svgEl);
+  if (!data.startsWith('<?xml')) {
+    data = '<?xml version="1.0" encoding="UTF-8"?>\n' + data;
+  }
+  const blob = new Blob([data], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = EXPORT_FILENAME;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  showStatus('SVG exported');
+}
+
+// ---- CSS animation handling ------------------------------------------------
+
+// Cache nodes with active CSS animations once — walking all descendants and
+// calling getComputedStyle on every play/pause/restart is O(N) layout work.
+function collectCssAnimNodes(root) {
+  const all = [root, ...root.querySelectorAll('*')];
+  return all.filter((el) => {
+    const name = getComputedStyle(el).animationName;
+    return name && name !== 'none';
+  });
+}
+
+function setCssPlayState(state) {
+  __cssAnimNodes.forEach((el) => {
+    el.style.animationPlayState = state;
+  });
+}
+
+function restartCssAnimations() {
+  __cssAnimNodes.forEach((el) => {
+    el.style.animation = 'none';
+    void el.offsetWidth; // force reflow so the next assignment restarts
+    el.style.animation = '';
+  });
+}
+
+// ---- Scrubber --------------------------------------------------------------
+
+function wireScrub(svgEl, total) {
+  if (!__scrubEl) return;
+
+  __scrubEl.addEventListener('input', () => {
+    const t = (__scrubEl.value / SCRUB_RESOLUTION) * total;
+    if (typeof svgEl.setCurrentTime === 'function') {
+      svgEl.setCurrentTime(t);
+    }
+  });
+
+  // Visual-only sync of the thumb with SMIL playback (no numeric label).
+  // Programmatic assignment doesn't fire 'input', so no event loop.
+  if (typeof svgEl.getCurrentTime === 'function') {
+    setInterval(() => {
+      if (__svgPaused) return;
+      const t = svgEl.getCurrentTime() % (total || 1);
+      const next = String(Math.min(SCRUB_RESOLUTION, Math.round((t / total) * SCRUB_RESOLUTION)));
+      if (next !== __scrubEl.value) __scrubEl.value = next;
+    }, SCRUB_POLL_MS);
+  }
+}
+
+// ---- Zoom & pan via viewBox manipulation -----------------------------------
+
+function setupZoomAndPan(svgEl) {
+  const viewBox = svgEl.getAttribute('viewBox');
+  if (!viewBox) return null;
+  const [ox, oy, ow, oh] = viewBox.split(/\s+/).map(Number);
+
+  let scale = 1;
+  let tx = 0;
+  let ty = 0;
+  let dragging = false;
+  let startX = 0;
+  let startY = 0;
+  let startTx = 0;
+  let startTy = 0;
+
+  function apply() {
+    const w = ow / scale;
+    const h = oh / scale;
+    const x = ox - tx / scale + (ow - w) / 2;
+    const y = oy - ty / scale + (oh - h) / 2;
+    svgEl.setAttribute('viewBox', `${x} ${y} ${w} ${h}`);
+  }
+
+  svgEl.addEventListener(
+    'wheel',
+    (e) => {
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+      scale = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, scale * factor));
+      apply();
+    },
+    { passive: false }
+  );
+
+  svgEl.addEventListener('mousedown', (e) => {
+    dragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+    startTx = tx;
+    startTy = ty;
+    svgEl.style.cursor = 'grabbing';
+  });
+  window.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    tx = startTx + (e.clientX - startX);
+    ty = startTy + (e.clientY - startY);
+    apply();
+  });
+  window.addEventListener('mouseup', () => {
+    dragging = false;
+    svgEl.style.cursor = 'grab';
+  });
+
+  svgEl.style.cursor = 'grab';
+
+  return {
+    reset() {
+      scale = 1;
+      tx = 0;
+      ty = 0;
+      apply();
+    },
+  };
+}
+
+// ---- Error helper ----------------------------------------------------------
+
+function showError(message) {
+  const stage = document.querySelector('.svg-stage') || __svgPreviewContainer;
+  const box = document.createElement('div');
+  box.className = 'svg-error';
+  const title = document.createElement('div');
+  title.className = 'svg-error-title';
+  title.textContent = 'SVG Render Error';
+  const msg = document.createElement('div');
+  msg.className = 'svg-error-msg';
+  msg.textContent = message;
+  box.appendChild(title);
+  box.appendChild(msg);
+  stage.appendChild(box);
+  console.error('SVG preview error:', message);
+}

--- a/skills/preview-svg/templates/scripts/utils.js
+++ b/skills/preview-svg/templates/scripts/utils.js
@@ -1,0 +1,66 @@
+//==============================================================================
+// AUTO-GENERATED - DO NOT EDIT
+//==============================================================================
+// Source: src/core/templates/scripts/utils.js
+// To edit: Modify source file, then run: src/scripts/sync-skills.sh
+//==============================================================================
+
+/**
+ * Browser Utilities for Preview Skills
+ */
+
+/**
+ * UTF-8 safe base64 decode
+ * Handles Unicode characters properly
+ * @param {string} str - Base64 encoded string
+ * @returns {string} Decoded UTF-8 string
+ */
+// eslint-disable-next-line no-unused-vars
+function base64DecodeUnicode(str) {
+  return decodeURIComponent(
+    atob(str)
+      .split('')
+      .map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join('')
+  );
+}
+
+/**
+ * Get element by ID safely
+ * @param {string} id - Element ID
+ * @returns {HTMLElement|null} Element or null if not found
+ */
+function getElement(id) {
+  return document.getElementById(id);
+}
+
+/**
+ * Set element content
+ * @param {string} id - Element ID
+ * @param {string} content - HTML content to set
+ * @deprecated WARNING: This function uses innerHTML and should ONLY be used
+ * with trusted/sanitized content. For untrusted content, use textContent
+ * or sanitize with DOMPurify first. Consider using setTextContent() instead.
+ */
+// eslint-disable-next-line no-unused-vars
+function setContent(id, content) {
+  const element = getElement(id);
+  if (element) {
+    element.innerHTML = content;
+  }
+}
+
+/**
+ * Set element text content safely (XSS-safe)
+ * @param {string} id - Element ID
+ * @param {string} text - Plain text content to set
+ */
+// eslint-disable-next-line no-unused-vars
+function setTextContent(id, text) {
+  const element = getElement(id);
+  if (element) {
+    element.textContent = text;
+  }
+}

--- a/skills/preview-svg/templates/styles/common.css
+++ b/skills/preview-svg/templates/styles/common.css
@@ -1,0 +1,70 @@
+/*==============================================================================
+ * AUTO-GENERATED - DO NOT EDIT
+ *==============================================================================
+ * Source: src/core/templates/styles/common.css
+ * To edit: Modify source file, then run: src/scripts/sync-skills.sh
+ *============================================================================*/
+
+/* Common Styles - Shared across all preview skills */
+
+/* CSS Reset */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+/* Body - Base styles */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    line-height: 1.6;
+    color: #333;
+}
+
+/* Layout: Document (for text-heavy content like markdown) */
+.layout-document {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.layout-document #content {
+    background: white;
+    padding: 40px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+/* Layout: Centered (for diagrams, images) */
+.layout-centered {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.layout-centered #content {
+    background: white;
+    padding: 10px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    max-width: 100%;
+}
+
+/* Layout: Full width (for interactive content) */
+.layout-full {
+    width: 100%;
+    height: 100vh;
+}
+
+.layout-full #content {
+    width: 100%;
+    height: 100%;
+}
+
+/* Card styling (alternative to content wrapper) */
+.card {
+    background: white;
+    padding: 10px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}

--- a/skills/preview-svg/templates/styles/layout.css
+++ b/skills/preview-svg/templates/styles/layout.css
@@ -1,0 +1,595 @@
+/*==============================================================================
+ * AUTO-GENERATED - DO NOT EDIT
+ *==============================================================================
+ * Source: src/core/templates/styles/layout.css
+ * To edit: Modify source file, then run: src/scripts/sync-skills.sh
+ *============================================================================*/
+
+/* Common Layout - Shared structure for all preview types */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+    /* Light Mode - Default */
+    --color-mode: 'light';
+
+    /* Typography */
+    --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-family-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+    --font-size-xs: 12px;
+    --font-size-sm: 13px;
+    --font-size-base: 14px;
+    --font-size-lg: 16px;
+    --font-size-xl: 18px;
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+    --line-height-tight: 1.25;
+    --line-height-normal: 1.5;
+    --line-height-relaxed: 1.75;
+
+    /* Spacing */
+    --spacing-xs: 4px;
+    --spacing-6: 6px;
+    --spacing-sm: 8px;
+    --spacing-10: 10px;
+    --spacing-md: 12px;
+    --spacing-lg: 16px;
+    --spacing-xl: 20px;
+    --spacing-2xl: 24px;
+
+    /* Border Radius */
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 16px;
+    --radius-full: 9999px;
+
+    /* Transitions */
+    --transition-fast: 0.15s;
+    --transition-base: 0.2s;
+    --transition-slow: 0.3s;
+
+    /* Primary Colors */
+    --color-primary: #3b82f6;
+    --color-primary-hover: #2563eb;
+    --color-primary-light: #60a5fa;
+    --color-secondary: #8b5cf6;
+    --color-secondary-hover: #7c3aed;
+
+    /* Background Colors */
+    --color-bg-base: #ffffff;
+    --color-bg-alt: #f9fafb;
+    --color-bg-elevated: #ffffff;
+    --color-bg-overlay: rgba(255, 255, 255, 0.95);
+
+    /* Text Colors */
+    --color-text-primary: #0f172a;
+    --color-text-secondary: #475569;
+    --color-text-tertiary: #64748b;
+    --color-text-disabled: #94a3b8;
+    --color-text-inverse: #ffffff;
+
+    /* Border Colors */
+    --color-border-primary: #e2e8f0;
+    --color-border-secondary: #cbd5e1;
+    --color-border-focus: #3b82f6;
+
+    /* Surface Colors */
+    --color-surface-primary: #ffffff;
+    --color-surface-secondary: #f8fafc;
+    --color-surface-tertiary: #f1f5f9;
+    --color-surface-hover: #f8fafc;
+
+    /* Status Colors */
+    --color-success: #10b981;
+    --color-success-bg: #d1fae5;
+    --color-error: #ef4444;
+    --color-error-bg: #fee2e2;
+    --color-warning: #f59e0b;
+    --color-warning-bg: #fef3c7;
+    --color-info: #3b82f6;
+    --color-info-bg: #dbeafe;
+
+    /* Shadow Colors */
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+
+    /* Header/Footer Colors */
+    --color-header-bg: #f8fafc;
+    --color-header-text: var(--color-text-primary);
+    --color-header-border: var(--color-border-secondary);
+    --color-footer-bg: #f8fafc;
+}
+
+[data-theme="dark"] {
+    --color-mode: 'dark';
+
+    /* Primary Colors */
+    --color-primary: #60a5fa;
+    --color-primary-hover: #3b82f6;
+    --color-primary-light: #93c5fd;
+    --color-secondary: #a78bfa;
+    --color-secondary-hover: #8b5cf6;
+
+    /* Background Colors */
+    --color-bg-base: #0f172a;
+    --color-bg-alt: #1e293b;
+    --color-bg-elevated: #1e293b;
+    --color-bg-overlay: rgba(15, 23, 42, 0.95);
+
+    /* Text Colors */
+    --color-text-primary: #f1f5f9;
+    --color-text-secondary: #cbd5e1;
+    --color-text-tertiary: #94a3b8;
+    --color-text-disabled: #64748b;
+    --color-text-inverse: #0f172a;
+
+    /* Border Colors */
+    --color-border-primary: #334155;
+    --color-border-secondary: #475569;
+    --color-border-focus: #60a5fa;
+
+    /* Surface Colors */
+    --color-surface-primary: #1e293b;
+    --color-surface-secondary: #0f172a;
+    --color-surface-tertiary: #334155;
+    --color-surface-hover: #334155;
+
+    /* Status Colors */
+    --color-success: #34d399;
+    --color-success-bg: #064e3b;
+    --color-error: #f87171;
+    --color-error-bg: #7f1d1d;
+    --color-warning: #fbbf24;
+    --color-warning-bg: #78350f;
+    --color-info: #60a5fa;
+    --color-info-bg: #1e3a8a;
+
+    /* Shadow Colors */
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
+
+    /* Header/Footer Colors */
+    --color-header-bg: #0f172a;
+    --color-header-text: var(--color-text-primary);
+    --color-header-border: var(--color-border-secondary);
+    --color-footer-bg: #0f172a;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    overflow: hidden;
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-normal);
+    line-height: var(--line-height-normal);
+    background: var(--color-bg-base);
+    color: var(--color-text-primary);
+    transition: background-color var(--transition-slow) ease, color var(--transition-slow) ease;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+#content {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
+}
+
+/* Theme Toggle Switch */
+.theme-toggle-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-left: auto;
+}
+
+.theme-toggle {
+    position: relative;
+    width: 52px;
+    height: 28px;
+    background: var(--color-surface-secondary);
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all var(--transition-slow) ease;
+    border: 1px solid var(--color-border-primary);
+}
+
+.theme-toggle::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 22px;
+    height: 22px;
+    background: var(--color-primary);
+    border-radius: var(--radius-full);
+    transition: all var(--transition-slow) ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .theme-toggle::after {
+    transform: translateX(24px);
+}
+
+.theme-toggle:hover {
+    background: var(--color-surface-hover);
+}
+
+.theme-label {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-medium);
+    user-select: none;
+}
+
+/* Header */
+.preview-header {
+    background: var(--color-header-bg);
+    color: var(--color-header-text);
+    border-bottom: 1px solid var(--color-header-border);
+    padding: var(--spacing-md) var(--spacing-2xl);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+    flex-shrink: 0;
+    box-shadow: var(--shadow-sm);
+}
+
+.preview-header-info {
+    display: flex;
+    align-items: baseline;
+    gap: var(--spacing-md);
+}
+
+.preview-header-title {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: -0.02em;
+    margin: 0;
+    color: var(--color-header-text);
+}
+
+.preview-header-stats {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-normal);
+    color: var(--color-text-disabled);
+    padding: 0;
+    background: transparent;
+    border: none;
+}
+
+.preview-header-stats::before {
+    content: '•';
+    margin-right: var(--spacing-sm);
+    color: var(--color-text-disabled);
+}
+
+.preview-toolbar {
+    display: flex;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+/* Search Box */
+.search-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.search-input {
+    padding: var(--spacing-sm) var(--spacing-md) var(--spacing-sm) 36px;
+    border: 1px solid var(--color-border-primary);
+    background: var(--color-surface-primary);
+    border-radius: var(--radius-md);
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-normal);
+    width: 220px;
+    transition: all var(--transition-base);
+    color: var(--color-text-primary);
+}
+
+.search-input::placeholder {
+    color: var(--color-text-tertiary);
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    width: 280px;
+}
+
+.search-icon {
+    position: absolute;
+    left: var(--spacing-md);
+    color: var(--color-primary);
+    font-size: var(--font-size-lg);
+    pointer-events: none;
+}
+
+.search-clear {
+    position: absolute;
+    right: var(--spacing-sm);
+    background: none;
+    border: none;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    padding: var(--spacing-xs);
+    display: none;
+    font-size: var(--font-size-lg);
+    border-radius: var(--radius-sm);
+    transition: background var(--transition-base);
+}
+
+.search-clear:hover {
+    background: var(--color-surface-hover);
+}
+
+.search-input:not(:placeholder-shown) ~ .search-clear {
+    display: block;
+}
+
+/* Action Buttons */
+.action-btn {
+    background: var(--color-surface-primary);
+    color: var(--color-primary);
+    border: 1px solid var(--color-border-primary);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    transition: all var(--transition-base);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-6);
+}
+
+.action-btn:hover {
+    background: var(--color-bg-base);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.action-btn:active {
+    transform: translateY(0);
+}
+
+/* Preview Body */
+.preview-body {
+    flex: 1;
+    overflow: auto;
+    background: var(--color-bg-alt);
+    scroll-behavior: smooth;
+    padding-left: var(--spacing-2xl);
+    padding-right: var(--spacing-2xl);
+}
+
+/* Scrollbar Styling - Reusable */
+.preview-body::-webkit-scrollbar,
+#csv-container::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+.preview-body::-webkit-scrollbar-track,
+#csv-container::-webkit-scrollbar-track {
+    background: var(--color-surface-secondary);
+}
+
+.preview-body::-webkit-scrollbar-thumb,
+#csv-container::-webkit-scrollbar-thumb {
+    background: var(--color-border-secondary);
+    border-radius: var(--radius-sm);
+}
+
+.preview-body::-webkit-scrollbar-thumb:hover,
+#csv-container::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-tertiary);
+}
+
+#csv-container::-webkit-scrollbar-corner {
+    background: var(--color-surface-secondary);
+}
+
+/* Footer */
+.preview-footer {
+    background: var(--color-footer-bg);
+    border-top: 1px solid var(--color-header-border);
+    padding: var(--spacing-10) var(--spacing-2xl);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-md);
+    font-family: var(--font-family);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-normal);
+    color: var(--color-text-secondary);
+    flex-shrink: 0;
+}
+
+@media (min-width: 640px) {
+    .preview-footer {
+        flex-direction: row;
+    }
+}
+
+.footer-links {
+    display: flex;
+    gap: var(--spacing-lg);
+    align-items: center;
+}
+
+.footer-link {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-6);
+    transition: color var(--transition-base);
+    font-weight: var(--font-weight-normal);
+}
+
+.footer-link:hover {
+    color: var(--color-text-primary);
+}
+
+.footer-link svg {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+}
+
+.footer-copyright {
+    color: var(--color-text-secondary);
+}
+
+.footer-author {
+    color: var(--color-text-primary);
+    text-decoration: none;
+    transition: color var(--transition-base);
+    font-weight: var(--font-weight-medium);
+}
+
+.footer-author:hover {
+    color: var(--color-primary);
+}
+
+/* Status Message */
+.status-message {
+    position: fixed;
+    bottom: var(--spacing-2xl);
+    right: var(--spacing-2xl);
+    background: var(--color-success);
+    color: var(--color-text-inverse);
+    padding: var(--spacing-md) var(--spacing-xl);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    animation: slideIn var(--transition-slow) ease-out;
+    z-index: 1000;
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(400px);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideOut {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(400px);
+        opacity: 0;
+    }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .preview-header {
+        position: relative;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        padding: var(--spacing-sm) var(--spacing-md);
+        padding-right: 70px;
+        gap: var(--spacing-sm);
+    }
+
+    .preview-header-info {
+        flex: 1 1 100%;
+        order: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-xs);
+    }
+
+    .preview-header-title {
+        font-size: var(--font-size-base);
+    }
+
+    .preview-header-stats {
+        font-size: 11px;
+        word-break: break-word;
+    }
+
+    .preview-header-stats::before {
+        display: none;
+    }
+
+    .preview-header .theme-toggle-wrapper {
+        position: absolute !important;
+        top: var(--spacing-sm) !important;
+        right: var(--spacing-md) !important;
+        order: 999;
+        margin: 0 !important;
+    }
+
+    .preview-header .theme-toggle-wrapper .theme-label {
+        display: none !important;
+    }
+
+    .preview-toolbar {
+        flex: 1 1 100%;
+        order: 3;
+        display: flex;
+        gap: var(--spacing-sm);
+        flex-wrap: wrap;
+    }
+
+    .search-box {
+        flex: 1 1 100%;
+        order: 1;
+    }
+
+    .action-btn {
+        flex: 1 1 auto;
+        min-width: fit-content;
+        order: 2;
+    }
+
+    .search-input {
+        width: 100%;
+    }
+
+    .search-input:focus {
+        width: 100%;
+    }
+
+    .preview-footer {
+        display: none !important;
+    }
+
+    .footer-links {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-sm);
+    }
+}

--- a/skills/preview-svg/templates/styles/svg.css
+++ b/skills/preview-svg/templates/styles/svg.css
@@ -1,0 +1,173 @@
+/* SVG Animation Preview Styles */
+
+.preview-body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 0 !important;
+  height: calc(100vh - 140px);
+  overflow: hidden;
+  background: var(--color-bg-alt);
+}
+
+/* The visual stage that holds the rendered SVG. */
+.svg-stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-base);
+  overflow: hidden;
+  position: relative;
+}
+
+.svg-stage > svg.preview-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+/* Timeline bar */
+.svg-timeline-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-xl);
+  background: var(--color-surface-primary);
+  border-top: 1px solid var(--color-border-primary);
+  flex-shrink: 0;
+}
+
+/* Playback buttons sit inline before the scrubber */
+.svg-play-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  line-height: 1;
+  transition: background var(--transition-base), transform var(--transition-base);
+  flex-shrink: 0;
+}
+
+.svg-play-btn:hover {
+  background: var(--color-primary-hover);
+  transform: scale(1.05);
+}
+
+.svg-play-btn:active {
+  transform: scale(0.95);
+}
+
+.svg-icon-pause {
+  font-weight: 700;
+  letter-spacing: -1px;
+}
+
+.svg-icon-play {
+  margin-left: 2px; /* visual centering for the triangle */
+}
+
+.svg-scrub-wrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.svg-scrub {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  background: var(--color-border-primary);
+  border-radius: 2px;
+  outline: none;
+}
+
+.svg-scrub::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+  border: 2px solid var(--color-surface-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.svg-scrub::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+  border: 2px solid var(--color-surface-primary);
+}
+
+.svg-time {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  min-width: 40px;
+}
+
+.svg-time-start {
+  text-align: right;
+}
+
+.svg-time-end {
+  text-align: left;
+}
+
+/* Code panel (toggleable) */
+.svg-code-panel {
+  margin: 0;
+  padding: var(--spacing-lg);
+  max-height: 260px;
+  overflow: auto;
+  background: var(--color-surface-tertiary);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
+  border-top: 1px solid var(--color-border-primary);
+  white-space: pre;
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .svg-code-panel {
+  background: #0b1220;
+}
+
+/* Error display */
+.svg-error {
+  padding: var(--spacing-2xl);
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  border-radius: var(--radius-md);
+  max-width: 600px;
+  text-align: center;
+}
+
+.svg-error-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--spacing-sm);
+}
+
+.svg-error-msg {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  word-break: break-word;
+}


### PR DESCRIPTION
## Summary

Adds `preview-svg`, a new skill for rendering animated SVGs in a controllable browser preview. Built for explaining hard concepts visually — SMIL, CSS keyframes, and inline JS all work.

## What's included

- **Skill**: `skills/preview-svg/` with `SKILL.md`, `config.sh`, `templates/scripts/svg-renderer.js`, `templates/styles/svg.css` (shared lib/template files synced from `src/core` via `scripts/sync-skills.sh svg`)
- **Renderer features**: Play/Pause, Restart, timeline scrub (SMIL `setCurrentTime`), zoom & pan via viewBox manipulation, code-view toggle, SVG export. Auto-detects animation features (SMIL / CSS anim / JS / static) and estimates loop period from `dur`/`begin` attrs (including semicolon begin-lists for staggered repeats).
- **Examples** in `examples/svg/`:
  - `heartbeat.svg` — pulsing ECG with synced halo, particle burst, and P-QRS-T waveform trace
  - `motion-path.svg` — element following a bezier path with `<animateMotion>` + `<mpath>`
  - `bubble-sort.svg` — 4-bar bubble sort, 5 comparison steps over 8s
  - `load-balancer.svg` — 6 staggered requests on a 6s round-robin loop across 3 backends
- **Wiring**: added to `scripts/install.sh` AVAILABLE_SKILLS, `scripts/generate-docs.sh`, `docs/index.html` skill card, and `README.md` table + Examples block

## Notes

- The renderer's `showError` and SVG-export plumbing duplicate similar patterns already present in `d3-renderer.js`, `threejs-renderer.js`, and `leaflet-renderer.js`. Extracting those into `src/core/templates/scripts/common-ui.js` would be a follow-up that touches all skills — left out of this PR.

## Test plan

- [x] `npm run test` — all 252 tests pass
- [x] `npm run format` — clean
- [x] Verified rendered output for all four examples (play/pause, scrub, zoom, export, theme toggle)
- [x] `./scripts/generate-docs.sh` regenerates `docs/examples/svg/*.html` cleanly
- [x] `./scripts/install.sh preview-svg` symlinks the skill into `~/.claude/skills`