### PR TITLE
docs: link table entries to SKILL.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 **Reduce cognitive load when reviewing AI agent work.** Transform plans, diffs, and data into navigable previews.
 
-| Name                                                                                                  | Description                                                     | File Types          |
-| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------- |
-| [**preview-plan**](https://veelenga.github.io/preview-skills/examples/plan/sample.html)               | Navigable plans with sidebar TOC and progress tracking          | `.plan.md`, `.plan` |
-| [**preview-csv**](https://veelenga.github.io/preview-skills/examples/csv/employees.html)              | Sortable tables with search, filtering, and column statistics   | `.csv`              |
-| [**preview-json**](https://veelenga.github.io/preview-skills/examples/json/sample.html)               | Syntax highlighting with collapsible tree structure             | `.json`, `.jsonl`   |
-| [**preview-markdown**](https://veelenga.github.io/preview-skills/examples/markdown/sample.html)       | GitHub-flavored rendering with syntax highlighting              | `.md`, `.markdown`  |
-| [**preview-mermaid**](https://veelenga.github.io/preview-skills/examples/mermaid/sample.html)         | Interactive diagrams (flowcharts, sequences, ER, etc.)          | `.mmd`, `.mermaid`  |
-| [**preview-diff**](https://veelenga.github.io/preview-skills/examples/diff/feature.html)              | GitHub-style diffs with side-by-side comparison                 | `.diff`, `.patch`   |
-| [**preview-d3**](https://veelenga.github.io/preview-skills/examples/d3/sample.html)                   | Interactive 2D data visualizations with zoom and pan            | `.d3`               |
-| [**preview-threejs**](https://veelenga.github.io/preview-skills/examples/threejs/sample.html)         | Interactive 3D visualizations with orbit controls               | `.threejs`, `.3d`   |
-| [**preview-leaflet**](https://veelenga.github.io/preview-skills/examples/leaflet/longest-trails.html) | Interactive maps with markers and routes                        | `.leaflet`, `.map`  |
-| [**preview-svg**](https://veelenga.github.io/preview-skills/examples/svg/bubble-sort.html)            | Animated SVGs with play/pause, scrub, zoom — concept explainers | `.svg`              |
+| Name                                                                                                          | Description                                                     | File Types          |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------- |
+| [**preview-plan**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-plan/SKILL.md)         | Navigable plans with sidebar TOC and progress tracking          | `.plan.md`, `.plan` |
+| [**preview-csv**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-csv/SKILL.md)           | Sortable tables with search, filtering, and column statistics   | `.csv`              |
+| [**preview-json**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-json/SKILL.md)         | Syntax highlighting with collapsible tree structure             | `.json`, `.jsonl`   |
+| [**preview-markdown**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-markdown/SKILL.md) | GitHub-flavored rendering with syntax highlighting              | `.md`, `.markdown`  |
+| [**preview-mermaid**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-mermaid/SKILL.md)   | Interactive diagrams (flowcharts, sequences, ER, etc.)          | `.mmd`, `.mermaid`  |
+| [**preview-svg**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-svg/SKILL.md)           | Animated SVGs with play/pause, scrub, zoom — concept explainers | `.svg`              |
+| [**preview-diff**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-diff/SKILL.md)         | GitHub-style diffs with side-by-side comparison                 | `.diff`, `.patch`   |
+| [**preview-d3**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-d3/SKILL.md)             | Interactive 2D data visualizations with zoom and pan            | `.d3`               |
+| [**preview-threejs**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-threejs/SKILL.md)   | Interactive 3D visualizations with orbit controls               | `.threejs`, `.3d`   |
+| [**preview-leaflet**](https://github.com/veelenga/preview-skills/blob/main/skills/preview-leaflet/SKILL.md)   | Interactive maps with markers and routes                        | `.leaflet`, `.map`  |
 
 ![Demo](docs/demo.gif)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -761,6 +761,56 @@
         </div>
 
         <div class="skill-card glass">
+          <h3>preview-svg</h3>
+          <p>Animated SVG previews with play/pause, timeline scrubbing, and zoom for explaining concepts visually.</p>
+          <div class="file-types">
+            <span class="file-type">.svg</span>
+          </div>
+          <div class="example-links">
+            <a href="examples/svg/heartbeat.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              ECG Heartbeat
+            </a>
+            <a href="examples/svg/motion-path.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              Motion path
+            </a>
+            <a href="examples/svg/bubble-sort.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              Bubble sort
+            </a>
+            <a href="examples/svg/load-balancer.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              Load balancer
+            </a>
+            <a href="examples/svg/https-handshake.html" class="example-link">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+              HTTPS handshake
+            </a>
+          </div>
+        </div>
+
+        <div class="skill-card glass">
           <h3>preview-diff</h3>
           <p>GitHub-style diffs with side-by-side comparison and syntax highlighting.</p>
           <div class="file-types">
@@ -852,56 +902,6 @@
                 <line x1="10" y1="14" x2="21" y2="3"></line>
               </svg>
               Solar system
-            </a>
-          </div>
-        </div>
-
-        <div class="skill-card glass">
-          <h3>preview-svg</h3>
-          <p>Animated SVG previews with play/pause, timeline scrubbing, and zoom for explaining concepts visually.</p>
-          <div class="file-types">
-            <span class="file-type">.svg</span>
-          </div>
-          <div class="example-links">
-            <a href="examples/svg/heartbeat.html" class="example-link">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                <polyline points="15 3 21 3 21 9"></polyline>
-                <line x1="10" y1="14" x2="21" y2="3"></line>
-              </svg>
-              ECG Heartbeat
-            </a>
-            <a href="examples/svg/motion-path.html" class="example-link">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                <polyline points="15 3 21 3 21 9"></polyline>
-                <line x1="10" y1="14" x2="21" y2="3"></line>
-              </svg>
-              Motion path
-            </a>
-            <a href="examples/svg/bubble-sort.html" class="example-link">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                <polyline points="15 3 21 3 21 9"></polyline>
-                <line x1="10" y1="14" x2="21" y2="3"></line>
-              </svg>
-              Bubble sort
-            </a>
-            <a href="examples/svg/load-balancer.html" class="example-link">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                <polyline points="15 3 21 3 21 9"></polyline>
-                <line x1="10" y1="14" x2="21" y2="3"></line>
-              </svg>
-              Load balancer
-            </a>
-            <a href="examples/svg/https-handshake.html" class="example-link">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                <polyline points="15 3 21 3 21 9"></polyline>
-                <line x1="10" y1="14" x2="21" y2="3"></line>
-              </svg>
-              HTTPS handshake
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Replace example HTML links in the README table with full GitHub URLs pointing to each skill's `SKILL.md`, so the links resolve correctly when the README is mirrored on third-party platforms (npm, package registries, etc.).
- Reorder `preview-svg` to appear right after `preview-mermaid` in both the README table and the website (`docs/index.html`) so visualization-focused skills are grouped together.

## Test plan

- [x] `npm run format`
- [x] `npm run test` (252 passing)
- [ ] Verify rendered README on GitHub — table links open the respective `SKILL.md` files
- [ ] Verify website renders with `preview-svg` card between `preview-mermaid` and `preview-diff`