### PR TITLE
fix: TOC anchor clicks broken on GitHub Pages

### DIFF
--- a/skills/preview-markdown/templates/scripts/markdown-renderer.js
+++ b/skills/preview-markdown/templates/scripts/markdown-renderer.js
@@ -180,7 +180,7 @@ function generateTOC() {
       const target = document.getElementById(header.id);
       if (!target) return;
 
-      history.pushState(null, '', `#${header.id}`);
+      history.pushState(null, '', `${location.pathname}${location.search}#${header.id}`);
       const markdownMain = document.getElementById('markdown-main');
       scrollToElement(target, markdownMain);
       setTimeout(updateProgress, 100);
@@ -305,7 +305,7 @@ function setupAnchorScrolling() {
     if (!targetElement) return;
 
     e.preventDefault();
-    history.pushState(null, '', `#${targetId}`);
+    history.pushState(null, '', `${location.pathname}${location.search}#${targetId}`);
     scrollToElement(targetElement, markdownMain);
     setTimeout(updateProgress, 100);
   }

--- a/skills/preview-plan/templates/scripts/plan-renderer.js
+++ b/skills/preview-plan/templates/scripts/plan-renderer.js
@@ -173,7 +173,7 @@ function generateTOC() {
       const target = document.getElementById(header.id);
       if (!target) return;
 
-      history.pushState(null, '', `#${header.id}`);
+      history.pushState(null, '', `${location.pathname}${location.search}#${header.id}`);
       const planMain = document.getElementById('plan-main');
       scrollToElement(target, planMain);
       setTimeout(updateProgress, 100);
@@ -354,7 +354,7 @@ function setupAnchorScrolling() {
     if (!targetElement) return;
 
     e.preventDefault();
-    history.pushState(null, '', `#${targetId}`);
+    history.pushState(null, '', `${location.pathname}${location.search}#${targetId}`);
     scrollToElement(targetElement, planMain);
     setTimeout(updateProgress, 100);
   });

--- a/src/__tests__/scripts/markdown-renderer.test.js
+++ b/src/__tests__/scripts/markdown-renderer.test.js
@@ -547,7 +547,7 @@ describe('markdown-renderer.js', () => {
       const clickEvent = new MouseEvent('click', { bubbles: true });
       anchor.dispatchEvent(clickEvent);
 
-      expect(pushStateSpy).toHaveBeenCalledWith(null, '', '#test-section');
+      expect(pushStateSpy).toHaveBeenCalledWith(null, '', expect.stringMatching(/#test-section$/));
       pushStateSpy.mockRestore();
     });
 


### PR DESCRIPTION
## Summary

TOC clicks in `preview-plan` and `preview-markdown` were broken on the hosted examples (`veelenga.github.io/preview-skills/examples/...`). Clicking did nothing and the console showed:

```
SecurityError: Failed to execute 'pushState' on 'History':
A history state object with URL 'file:///home/runner/.../examples/plan/#section-id'
cannot be created in a document with origin 'https://veelenga.github.io'
```

### Root cause

Generated HTML includes `<base href="file:///.../">` so relative image refs work when the file is opened locally. `history.pushState(null, '', '#id')` resolves the relative URL against the `<base>` tag → a `file://` URL. On GitHub Pages the document origin is `https://`, so pushState throws. The thrown error aborted the click handler before `scrollToElement` ran.

### Fix

Build the URL explicitly from `location.pathname + location.search`:

```js
history.pushState(null, '', `${location.pathname}${location.search}#${id}`);
```

This produces a same-origin absolute URL in both environments (file:// locally, https:// on Pages), so `<base>` no longer interferes.

## Test plan

- [x] `npm test` — 252/252 passing
- [x] Local: generated `examples/plan/sample.plan.md` preview, confirmed `pushState` line is the new form
- [x] Local: `<base href="file://...">` still present (image refs unaffected)
- [ ] After merge: verify TOC scrolling works on `https://veelenga.github.io/preview-skills/examples/plan/sample.html` and `.../examples/markdown/sample.html`