### PR TITLE
fix: suppress file:// <base> tag in docs build

### DIFF
--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -11,10 +11,9 @@ DOCS_DIR="$PROJECT_ROOT/docs"
 EXAMPLES_DIR="$PROJECT_ROOT/examples"
 SKILLS_DIR="$PROJECT_ROOT/skills"
 
-# Note: All skill scripts are called with --no-browser flag below.
-# Outputs are served from https://veelenga.github.io/preview-skills/, so the
-# file:// <base> tag (default for local previews) would be a different origin
-# from the hosting site. Set HTML_BASE_HREF to empty to suppress it.
+# Note: All skill scripts are called with --no-browser flag below
+
+# Output is served via https://, so the file:// <base> default would be cross-origin.
 export HTML_BASE_HREF=""
 
 # Create docs/examples directories

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -11,7 +11,11 @@ DOCS_DIR="$PROJECT_ROOT/docs"
 EXAMPLES_DIR="$PROJECT_ROOT/examples"
 SKILLS_DIR="$PROJECT_ROOT/skills"
 
-# Note: All skill scripts are called with --no-browser flag below
+# Note: All skill scripts are called with --no-browser flag below.
+# Outputs are served from https://veelenga.github.io/preview-skills/, so the
+# file:// <base> tag (default for local previews) would be a different origin
+# from the hosting site. Set HTML_BASE_HREF to empty to suppress it.
+export HTML_BASE_HREF=""
 
 # Create docs/examples directories
 mkdir -p "$DOCS_DIR/examples"/{csv,json,markdown,mermaid,diff,d3,threejs,leaflet,plan,svg}

--- a/skills/preview-csv/run.sh
+++ b/skills/preview-csv/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-csv/run.sh
+++ b/skills/preview-csv/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-d3/run.sh
+++ b/skills/preview-d3/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-d3/run.sh
+++ b/skills/preview-d3/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-diff/run.sh
+++ b/skills/preview-diff/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-diff/run.sh
+++ b/skills/preview-diff/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-json/run.sh
+++ b/skills/preview-json/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-json/run.sh
+++ b/skills/preview-json/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-leaflet/run.sh
+++ b/skills/preview-leaflet/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-leaflet/run.sh
+++ b/skills/preview-leaflet/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-markdown/run.sh
+++ b/skills/preview-markdown/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-markdown/run.sh
+++ b/skills/preview-markdown/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-markdown/templates/scripts/markdown-renderer.js
+++ b/skills/preview-markdown/templates/scripts/markdown-renderer.js
@@ -180,7 +180,7 @@ function generateTOC() {
       const target = document.getElementById(header.id);
       if (!target) return;
 
-      history.pushState(null, '', `${location.pathname}${location.search}#${header.id}`);
+      history.pushState(null, '', `#${header.id}`);
       const markdownMain = document.getElementById('markdown-main');
       scrollToElement(target, markdownMain);
       setTimeout(updateProgress, 100);
@@ -305,7 +305,7 @@ function setupAnchorScrolling() {
     if (!targetElement) return;
 
     e.preventDefault();
-    history.pushState(null, '', `${location.pathname}${location.search}#${targetId}`);
+    history.pushState(null, '', `#${targetId}`);
     scrollToElement(targetElement, markdownMain);
     setTimeout(updateProgress, 100);
   }

--- a/skills/preview-mermaid/run.sh
+++ b/skills/preview-mermaid/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-mermaid/run.sh
+++ b/skills/preview-mermaid/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-plan/run.sh
+++ b/skills/preview-plan/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-plan/run.sh
+++ b/skills/preview-plan/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-plan/templates/scripts/plan-renderer.js
+++ b/skills/preview-plan/templates/scripts/plan-renderer.js
@@ -173,7 +173,7 @@ function generateTOC() {
       const target = document.getElementById(header.id);
       if (!target) return;
 
-      history.pushState(null, '', `${location.pathname}${location.search}#${header.id}`);
+      history.pushState(null, '', `#${header.id}`);
       const planMain = document.getElementById('plan-main');
       scrollToElement(target, planMain);
       setTimeout(updateProgress, 100);
@@ -354,7 +354,7 @@ function setupAnchorScrolling() {
     if (!targetElement) return;
 
     e.preventDefault();
-    history.pushState(null, '', `${location.pathname}${location.search}#${targetId}`);
+    history.pushState(null, '', `#${targetId}`);
     scrollToElement(targetElement, planMain);
     setTimeout(updateProgress, 100);
   });

--- a/skills/preview-svg/run.sh
+++ b/skills/preview-svg/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-svg/run.sh
+++ b/skills/preview-svg/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/skills/preview-threejs/run.sh
+++ b/skills/preview-threejs/run.sh
@@ -104,9 +104,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/skills/preview-threejs/run.sh
+++ b/skills/preview-threejs/run.sh
@@ -104,12 +104,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI

--- a/src/__tests__/scripts/markdown-renderer.test.js
+++ b/src/__tests__/scripts/markdown-renderer.test.js
@@ -547,7 +547,7 @@ describe('markdown-renderer.js', () => {
       const clickEvent = new MouseEvent('click', { bubbles: true });
       anchor.dispatchEvent(clickEvent);
 
-      expect(pushStateSpy).toHaveBeenCalledWith(null, '', expect.stringMatching(/#test-section$/));
+      expect(pushStateSpy).toHaveBeenCalledWith(null, '', '#test-section');
       pushStateSpy.mockRestore();
     });
 

--- a/src/preview-skills/run.sh
+++ b/src/preview-skills/run.sh
@@ -96,9 +96,13 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Set base href for relative path resolution (images, links, etc.)
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
-if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ]; then
+# Default HTML_BASE_HREF to the source file's directory so relative images
+# resolve when the preview is opened locally via file://.
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
+# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
+# generation for the web sets it empty because file:// would be a different
+# origin from the hosting site.
+if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI
     SOURCE_DIR_URL="${SOURCE_DIR_ABS//%/%25}"

--- a/src/preview-skills/run.sh
+++ b/src/preview-skills/run.sh
@@ -96,12 +96,9 @@ else
     CONTENT=$(read_with_limit "$MAX_CONTENT_SIZE") || exit 1
 fi
 
-# Default HTML_BASE_HREF to the source file's directory so relative images
-# resolve when the preview is opened locally via file://.
-# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src.
-# If the caller already set HTML_BASE_HREF (even to ""), respect it — e.g. docs
-# generation for the web sets it empty because file:// would be a different
-# origin from the hosting site.
+# Set base href for relative path resolution (images, links, etc.)
+# Skip for interactive tools (D3, ThreeJS, Leaflet) that load user code via relative script src
+# Skip if caller pre-set HTML_BASE_HREF (including empty) — ${VAR+x} distinguishes unset from set-empty
 if [ -n "${SOURCE_FILE:-}" ] && [ "${NEEDS_USER_CODE_TEMPLATE:-0}" != "1" ] && [ -z "${HTML_BASE_HREF+x}" ]; then
     SOURCE_DIR_ABS="$(cd "$(dirname "$SOURCE_FILE")" && pwd)"
     # Encode URL-unsafe characters for file:// URI


### PR DESCRIPTION
## Summary

Fix TOC scrolling.

The issue: the generated HTML uses `<base href="file://...">` to resolve relative images for local previews, but that base is wrong when the same HTML is served from GitHub Pages.

## Fix

- `scripts/generate-docs.sh`: `export HTML_BASE_HREF=""` so the web build omits `<base>`.
- `src/preview-skills/run.sh`: only set the default `HTML_BASE_HREF` if the caller hasn't.
- Revert the pushState rewrite from #25 — `#${id}` is correct once `<base>` is gone.

## Test plan

- [x] `npm test` — 252/252
- [x] Local preview still emits `<base href="file://...">`
- [x] Docs build emits no `<base>` tag
- [ ] After merge: TOC scrolls on the deployed plan/markdown examples